### PR TITLE
MB-60029 - Add function to set nprobe for IVF index.

### DIFF
--- a/index_ivf.go
+++ b/index_ivf.go
@@ -38,7 +38,7 @@ func (idx *IndexImpl) GetSubIndex() (*IndexImpl, error) {
 	return &IndexImpl{&faissIndex{subIdx}}, nil
 }
 
-// pass nprobe to be set as index time option.
+// pass nprobe to be set as index time option for IVF indexes only.
 // varying nprobe impacts recall but with an increase in latency.
 func (idx *IndexImpl) SetNProbe(nprobe int32) {
 	ivfPtr := C.faiss_IndexIVF_cast(idx.cPtr())

--- a/index_ivf.go
+++ b/index_ivf.go
@@ -37,3 +37,13 @@ func (idx *IndexImpl) GetSubIndex() (*IndexImpl, error) {
 
 	return &IndexImpl{&faissIndex{subIdx}}, nil
 }
+
+// pass nprobe to be set as index time option.
+// varying nprobe impacts recall but with an increase in latency.
+func (idx *IndexImpl) SetNProbe(nprobe int32) {
+	ivfPtr := C.faiss_IndexIVF_cast(idx.cPtr())
+	if ivfPtr == nil {
+		return
+	}
+	C.faiss_IndexIVF_set_nprobe(ivfPtr, C.ulong(nprobe))
+}


### PR DESCRIPTION
This PR adds a go-faiss function to set the nprobe for an IVF index.