### PR TITLE
MB-60202 - Exclude specific IDs at search time.

### DIFF
--- a/_example/ivfflat/ivfflat.go
+++ b/_example/ivfflat/ivfflat.go
@@ -37,13 +37,7 @@ func main() {
 		xq[i*d] += float32(i) / 1000
 	}
 
-	indexF, err := faiss.IndexFactory(d, "IDMap2,IVF100,SQ8", faiss.MetricInnerProduct)
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer indexF.Close()
-
-	index, err := indexF.GetSubIndex()
+	index, err := faiss.IndexFactory(d, "IVF100,SQ8", faiss.MetricInnerProduct)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -83,7 +77,9 @@ func main() {
 		log.Fatal(err)
 	}
 
-	_, ids, err = index.Search(xq, k)
+	// Definitive test - exclude ALL the IDs in an index
+	// The search results should all return -1.
+	_, ids, err = index.SearchWithoutIDs(xq, k, ids1)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/_example/ivfflat/ivfflat.go
+++ b/_example/ivfflat/ivfflat.go
@@ -41,6 +41,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+	defer index.Close()
 
 	index.SetDirectMap(2)
 

--- a/index.go
+++ b/index.go
@@ -3,6 +3,8 @@ package faiss
 /*
 #include <stdlib.h>
 #include <faiss/c_api/Index_c.h>
+#include <faiss/c_api/IndexIVF_c.h>
+#include <faiss/c_api/IndexIVF_c_ex.h>
 #include <faiss/c_api/Index_c_ex.h>
 #include <faiss/c_api/impl/AuxIndexStructures_c.h>
 #include <faiss/c_api/index_factory_c.h>
@@ -156,6 +158,15 @@ func (idx *faissIndex) SearchWithoutIDs(x []float32, k int64, exclude []int64) (
 
 	var sp *C.FaissSearchParameters
 	C.faiss_SearchParameters_new(&sp, (*C.FaissIDSelector)(excludeSelector.sel))
+	ivfPtr := C.faiss_IndexIVF_cast(idx.cPtr())
+	if ivfPtr != nil {
+		sp = C.faiss_SearchParametersIVF_cast(sp)
+		C.faiss_SearchParametersIVF_new_with_sel(&sp, (*C.FaissIDSelector)(excludeSelector.sel))
+	}
+	defer func() {
+		excludeSelector.Delete()
+		C.faiss_SearchParameters_free(sp)
+	}()
 
 	n := len(x) / idx.D()
 	distances = make([]float32, int64(n)*k)

--- a/selector.go
+++ b/selector.go
@@ -33,6 +33,8 @@ func NewIDSelectorBatch(indices []int64) (*IDSelector, error) {
 	return &IDSelector{(*C.FaissIDSelector)(sel)}, nil
 }
 
+// NewIDSelectorNot creates a new Not selector, wrapped arround a
+// batch selector, with the IDs in 'exclude'.
 func NewIDSelectorNot(exclude []int64) (*IDSelector, error) {
 	batchSelector, err := NewIDSelectorBatch(exclude)
 	if err != nil {

--- a/selector.go
+++ b/selector.go
@@ -33,6 +33,22 @@ func NewIDSelectorBatch(indices []int64) (*IDSelector, error) {
 	return &IDSelector{(*C.FaissIDSelector)(sel)}, nil
 }
 
+func NewIDSelectorNot(exclude []int64) (*IDSelector, error) {
+	batchSelector, err := NewIDSelectorBatch(exclude)
+	if err != nil {
+		return nil, err
+	}
+
+	var sel *C.FaissIDSelectorNot
+	if c := C.faiss_IDSelectorNot_new(
+		&sel,
+		batchSelector.sel,
+	); c != 0 {
+		return nil, getLastError()
+	}
+	return &IDSelector{(*C.FaissIDSelector)(sel)}, nil
+}
+
 // Delete frees the memory associated with s.
 func (s *IDSelector) Delete() {
 	C.faiss_IDSelector_free(s.sel)


### PR DESCRIPTION
This PR 
- adds a function which allows the user to specify IDs to exclude from a search. 
- adds a utility function to use a Not selector to do the same.
- adds the function to an example similar to the index type used in zapx, as part of the verification. 