### PR TITLE
MB-60739: Fix slicing issue 

### DIFF
--- a/index_io.go
+++ b/index_io.go
@@ -46,6 +46,14 @@ func WriteIndexIntoBuffer(idx Index) ([]byte, error) {
 	// the bufSize is of type size_t  which is equivalent to a uint in golang, so
 	// the conversion is safe.
 	val := unsafe.Slice((*byte)(unsafe.Pointer(tempBuf)), uint(bufSize))
+	// NOTE: This method is compatible with 64-bit systems but may encounter issues on 32-bit systems.
+	// leading to vector indexing being supported only for 64-bit systems.
+	// This limitation arises because the maximum allowed length of a slice on 32-bit systems
+	// is math.MaxInt32 (2^31-1), whereas the maximum value of a size_t in C++ is math.MaxUInt32
+	// (4^31-1), exceeding the maximum allowed size of a slice in Go.
+	// Consequently, the bufSize returned by faiss_write_index_buf might exceed the
+	// maximum allowed size of a slice in Go, leading to a panic when attempting to
+	// create the following slice rv.
 	rv := make([]byte, uint(bufSize))
 	// an explicit copy is necessary to free the memory on C heap and then return
 	// the rv back to the caller which is definitely on goruntime space (which will


### PR DESCRIPTION
- During the merging of segments, especially in high-load scenarios where we're indexing 2048-dimensional vectors, we might end up with a segment containing 3 million vectors. After completing the training process and creating the merged vector index, we serialize the index into a byte buffer in Faiss. This buffer typically has a length of 6.2 billion elements. However, in our current approach, we only extract the first 4.2 billion elements from the C array and write them to our zap segment, discarding the remaining 2.0 billion elements.
- This partial indexing can cause issues when attempting to deserialize the index from the segment in the ReadIndexFromBuffer function, leading to a crash.
- Our new approach ensures that the entire buffer is read into a Golang slice without any data loss.
- In the ReadIndexBuffer function, we retrieve the length of the buffer, which is of type `int64` and holds the value 6.2 billion. However, by converting it into an `int32` value using `C.int`, it wraps around the int64 value (6.2 billion) to a false value of 1.9 billion. This could lead to further corruption because C would only read 1.9 billion elements from the buffer and throw an exception because its unable to deserialize the buffer to a Faiss index.
- Thanks to @Thejas-bhat and @metonymic-smokey for their valuable help.