### PR TITLE
MB-60816: Using runtime.LockOSThread to bind the running goroutine to the specific OS thread.

### DIFF
--- a/autotune.go
+++ b/autotune.go
@@ -5,7 +5,10 @@ package faiss
 #include <faiss/c_api/AutoTune_c.h>
 */
 import "C"
-import "unsafe"
+import (
+	"runtime"
+	"unsafe"
+)
 
 type ParameterSpace struct {
 	ps *C.FaissParameterSpace
@@ -13,6 +16,9 @@ type ParameterSpace struct {
 
 // NewParameterSpace creates a new ParameterSpace.
 func NewParameterSpace() (*ParameterSpace, error) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	var ps *C.FaissParameterSpace
 	if c := C.faiss_ParameterSpace_new(&ps); c != 0 {
 		return nil, getLastError()
@@ -22,6 +28,9 @@ func NewParameterSpace() (*ParameterSpace, error) {
 
 // SetIndexParameter sets one of the parameters.
 func (p *ParameterSpace) SetIndexParameter(idx Index, name string, val float64) error {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	cname := C.CString(name)
 	defer C.free(unsafe.Pointer(cname))
 

--- a/index.go
+++ b/index.go
@@ -119,6 +119,9 @@ func (idx *faissIndex) Train(x []float32) error {
 }
 
 func (idx *faissIndex) Add(x []float32) error {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	n := len(x) / idx.D()
 	if c := C.faiss_Index_add(idx.idx, C.idx_t(n), (*C.float)(&x[0])); c != 0 {
 		return getLastError()
@@ -206,6 +209,9 @@ func (idx *faissIndex) SearchWithoutIDs(x []float32, k int64, exclude []int64) (
 }
 
 func (idx *faissIndex) Reconstruct(key int64) (recons []float32, err error) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	rv := make([]float32, idx.D())
 	if c := C.faiss_Index_reconstruct(
 		idx.idx,
@@ -244,6 +250,9 @@ func (i *IndexImpl) MergeFrom(other Index, add_id int64) error {
 }
 
 func (idx *faissIndex) MergeFrom(other Index, add_id int64) (err error) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	otherIdx, ok := other.(*faissIndex)
 	if !ok {
 		return fmt.Errorf("merge api not supported")
@@ -263,6 +272,9 @@ func (idx *faissIndex) MergeFrom(other Index, add_id int64) (err error) {
 func (idx *faissIndex) RangeSearch(x []float32, radius float32) (
 	*RangeSearchResult, error,
 ) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	n := len(x) / idx.D()
 	var rsr *C.FaissRangeSearchResult
 	if c := C.faiss_RangeSearchResult_new(&rsr, C.idx_t(n)); c != 0 {
@@ -281,6 +293,9 @@ func (idx *faissIndex) RangeSearch(x []float32, radius float32) (
 }
 
 func (idx *faissIndex) Reset() error {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	if c := C.faiss_Index_reset(idx.idx); c != 0 {
 		return getLastError()
 	}
@@ -288,6 +303,9 @@ func (idx *faissIndex) Reset() error {
 }
 
 func (idx *faissIndex) RemoveIDs(sel *IDSelector) (int, error) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	var nRemoved C.size_t
 	if c := C.faiss_Index_remove_ids(idx.idx, sel.sel, &nRemoved); c != 0 {
 		return 0, getLastError()

--- a/index.go
+++ b/index.go
@@ -13,6 +13,7 @@ package faiss
 import "C"
 import (
 	"fmt"
+	"runtime"
 	"unsafe"
 )
 
@@ -107,6 +108,9 @@ func (idx *faissIndex) MetricType() int {
 }
 
 func (idx *faissIndex) Train(x []float32) error {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	n := len(x) / idx.D()
 	if c := C.faiss_Index_train(idx.idx, C.idx_t(n), (*C.float)(&x[0])); c != 0 {
 		return getLastError()
@@ -123,6 +127,9 @@ func (idx *faissIndex) Add(x []float32) error {
 }
 
 func (idx *faissIndex) AddWithIDs(x []float32, xids []int64) error {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	n := len(x) / idx.D()
 	if c := C.faiss_Index_add_with_ids(
 		idx.idx,
@@ -159,6 +166,9 @@ func (idx *faissIndex) Search(x []float32, k int64) (
 func (idx *faissIndex) SearchWithoutIDs(x []float32, k int64, exclude []int64) (
 	distances []float32, labels []int64, err error,
 ) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	if len(exclude) <= 0 {
 		return idx.Search(x, k)
 	}
@@ -209,6 +219,9 @@ func (idx *faissIndex) Reconstruct(key int64) (recons []float32, err error) {
 }
 
 func (idx *faissIndex) ReconstructBatch(keys []int64, recons []float32) ([]float32, error) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	var err error
 	n := int64(len(keys))
 	if c := C.faiss_Index_reconstruct_batch(
@@ -331,6 +344,9 @@ type IndexImpl struct {
 // IndexFactory builds a composite index.
 // description is a comma-separated list of components.
 func IndexFactory(d int, description string, metric int) (*IndexImpl, error) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	cdesc := C.CString(description)
 	defer C.free(unsafe.Pointer(cdesc))
 	var idx faissIndex

--- a/index_io.go
+++ b/index_io.go
@@ -8,6 +8,7 @@ package faiss
 */
 import "C"
 import (
+	"runtime"
 	"unsafe"
 )
 
@@ -22,6 +23,9 @@ func WriteIndex(idx Index, filename string) error {
 }
 
 func WriteIndexIntoBuffer(idx Index) ([]byte, error) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	// the values to be returned by the faiss APIs
 	tempBuf := (*C.uchar)(C.malloc(C.size_t(0)))
 	bufSize := C.size_t(0)
@@ -75,6 +79,9 @@ func WriteIndexIntoBuffer(idx Index) ([]byte, error) {
 }
 
 func ReadIndexFromBuffer(buf []byte, ioflags int) (*IndexImpl, error) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	ptr := (*C.uchar)(unsafe.Pointer(&buf[0]))
 	size := C.size_t(len(buf))
 

--- a/index_io.go
+++ b/index_io.go
@@ -30,6 +30,9 @@ func WriteIndexIntoBuffer(idx Index) ([]byte, error) {
 	tempBuf := (*C.uchar)(C.malloc(C.size_t(0)))
 	bufSize := C.size_t(0)
 
+	// safe to free the c memory allocated while serializing the index
+	defer C.free(unsafe.Pointer(tempBuf))
+
 	if c := C.faiss_write_index_buf(
 		idx.cPtr(),
 		&bufSize,
@@ -50,6 +53,7 @@ func WriteIndexIntoBuffer(idx Index) ([]byte, error) {
 	// the bufSize is of type size_t  which is equivalent to a uint in golang, so
 	// the conversion is safe.
 	val := unsafe.Slice((*byte)(unsafe.Pointer(tempBuf)), uint(bufSize))
+
 	// NOTE: This method is compatible with 64-bit systems but may encounter issues on 32-bit systems.
 	// leading to vector indexing being supported only for 64-bit systems.
 	// This limitation arises because the maximum allowed length of a slice on 32-bit systems
@@ -69,12 +73,10 @@ func WriteIndexIntoBuffer(idx Index) ([]byte, error) {
 	// a cheaper calloc rather than malloc can be used to make any extra allocations
 	// cheaper.
 	copy(rv, val)
-	// safe to free the c memory allocated while serializing the index, and the rv
-	// is something that's present in go runtime so different address space altogether
-	// p.s: no need to free "val" since the underlying memory is same for both the
-	// vars
-	C.free(unsafe.Pointer(tempBuf))
+
+	// p.s: no need to free "val" since the underlying memory is same as tempBuf (deferred free)
 	val = nil
+
 	return rv, nil
 }
 

--- a/index_ivf.go
+++ b/index_ivf.go
@@ -8,9 +8,15 @@ package faiss
 #include <faiss/c_api/IndexIVF_c_ex.h>
 */
 import "C"
-import "fmt"
+import (
+	"fmt"
+	"runtime"
+)
 
 func (idx *IndexImpl) SetDirectMap(mapType int) (err error) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	ivfPtr := C.faiss_IndexIVF_cast(idx.cPtr())
 	if ivfPtr == nil {
 		return fmt.Errorf("index is not of ivf type")
@@ -25,6 +31,9 @@ func (idx *IndexImpl) SetDirectMap(mapType int) (err error) {
 }
 
 func (idx *IndexImpl) GetSubIndex() (*IndexImpl, error) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	ptr := C.faiss_IndexIDMap2_cast(idx.cPtr())
 	if ptr == nil {
 		return nil, fmt.Errorf("index is not a id map")

--- a/selector.go
+++ b/selector.go
@@ -4,6 +4,7 @@ package faiss
 #include <faiss/c_api/impl/AuxIndexStructures_c.h>
 */
 import "C"
+import "runtime"
 
 // IDSelector represents a set of IDs to remove.
 type IDSelector struct {
@@ -12,6 +13,9 @@ type IDSelector struct {
 
 // NewIDSelectorRange creates a selector that removes IDs on [imin, imax).
 func NewIDSelectorRange(imin, imax int64) (*IDSelector, error) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	var sel *C.FaissIDSelectorRange
 	c := C.faiss_IDSelectorRange_new(&sel, C.idx_t(imin), C.idx_t(imax))
 	if c != 0 {
@@ -22,6 +26,9 @@ func NewIDSelectorRange(imin, imax int64) (*IDSelector, error) {
 
 // NewIDSelectorBatch creates a new batch selector.
 func NewIDSelectorBatch(indices []int64) (*IDSelector, error) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	var sel *C.FaissIDSelectorBatch
 	if c := C.faiss_IDSelectorBatch_new(
 		&sel,
@@ -36,6 +43,9 @@ func NewIDSelectorBatch(indices []int64) (*IDSelector, error) {
 // NewIDSelectorNot creates a new Not selector, wrapped arround a
 // batch selector, with the IDs in 'exclude'.
 func NewIDSelectorNot(exclude []int64) (*IDSelector, error) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	batchSelector, err := NewIDSelectorBatch(exclude)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
- Using this method becomes important when there are thread_local objects being used on the C side of things which stores the data in the namespace of the OS thread. If goroutine gets assigned to a different OS thread there maybe unexpected behaviour with respect to the value of the thread_local object 
- This can lead to additional overhead in terms of thread context switches as mentioned in the golang issues page. 