### PR TITLE
MB-60913: Introducing jemalloc for Faiss

### DIFF
--- a/faiss.go
+++ b/faiss.go
@@ -5,10 +5,11 @@
 package faiss
 
 /*
-#cgo LDFLAGS: -lfaiss_c
+#cgo LDFLAGS: -ljemalloc_faiss -lfaiss_c
 
 #include <faiss/c_api/Index_c.h>
 #include <faiss/c_api/error_c.h>
+#include <faiss/c_api/jemalloc_stat.h>
 */
 import "C"
 import "errors"
@@ -28,3 +29,11 @@ const (
 	MetricBrayCurtis    = C.METRIC_BrayCurtis
 	MetricJensenShannon = C.METRIC_JensenShannon
 )
+
+func GetHeapMemoryUsed() uint64 {
+	return uint64(C.jm_allocated())
+}
+
+func GetHeapMemoryResident() uint64 {
+	return uint64(C.jm_resident())
+}

--- a/index_io.go
+++ b/index_io.go
@@ -27,7 +27,7 @@ func WriteIndexIntoBuffer(idx Index) ([]byte, error) {
 	defer runtime.UnlockOSThread()
 
 	// the values to be returned by the faiss APIs
-	tempBuf := (*C.uchar)(C.malloc(C.size_t(0)))
+	var tempBuf *C.uchar = nil
 	bufSize := C.size_t(0)
 
 	if c := C.faiss_write_index_buf(


### PR DESCRIPTION
- C.free always uses glibc's `free`, so we use the newly introduced `faiss_free_buf` FAISS API, which internally uses `faiss_free` that can point to `je_free` if `Faiss` is built by setting the `Enable Jemalloc` flag to ON. This prevents a` je_malloc` being freed using glibc's `free` instead of `je_free`
- Expose a global, exported method `GetFaissHeapMemoryUsage` that returns the heap memory currently in use by the memory allocator `Faiss` is built with, either `jemalloc` or glibc's `malloc`