### PR TITLE
Revert Thread Locking

### DIFF
--- a/autotune.go
+++ b/autotune.go
@@ -6,7 +6,6 @@ package faiss
 */
 import "C"
 import (
-	"runtime"
 	"unsafe"
 )
 
@@ -16,9 +15,6 @@ type ParameterSpace struct {
 
 // NewParameterSpace creates a new ParameterSpace.
 func NewParameterSpace() (*ParameterSpace, error) {
-	runtime.LockOSThread()
-	defer runtime.UnlockOSThread()
-
 	var ps *C.FaissParameterSpace
 	if c := C.faiss_ParameterSpace_new(&ps); c != 0 {
 		return nil, getLastError()
@@ -28,12 +24,10 @@ func NewParameterSpace() (*ParameterSpace, error) {
 
 // SetIndexParameter sets one of the parameters.
 func (p *ParameterSpace) SetIndexParameter(idx Index, name string, val float64) error {
-	runtime.LockOSThread()
 	cname := C.CString(name)
 
 	defer func() {
 		C.free(unsafe.Pointer(cname))
-		runtime.UnlockOSThread()
 	}()
 
 	c := C.faiss_ParameterSpace_set_index_parameter(

--- a/index.go
+++ b/index.go
@@ -13,7 +13,6 @@ package faiss
 import "C"
 import (
 	"fmt"
-	"runtime"
 	"unsafe"
 )
 
@@ -108,9 +107,6 @@ func (idx *faissIndex) MetricType() int {
 }
 
 func (idx *faissIndex) Train(x []float32) error {
-	runtime.LockOSThread()
-	defer runtime.UnlockOSThread()
-
 	n := len(x) / idx.D()
 	if c := C.faiss_Index_train(idx.idx, C.idx_t(n), (*C.float)(&x[0])); c != 0 {
 		return getLastError()
@@ -119,9 +115,6 @@ func (idx *faissIndex) Train(x []float32) error {
 }
 
 func (idx *faissIndex) Add(x []float32) error {
-	runtime.LockOSThread()
-	defer runtime.UnlockOSThread()
-
 	n := len(x) / idx.D()
 	if c := C.faiss_Index_add(idx.idx, C.idx_t(n), (*C.float)(&x[0])); c != 0 {
 		return getLastError()
@@ -130,9 +123,6 @@ func (idx *faissIndex) Add(x []float32) error {
 }
 
 func (idx *faissIndex) AddWithIDs(x []float32, xids []int64) error {
-	runtime.LockOSThread()
-	defer runtime.UnlockOSThread()
-
 	n := len(x) / idx.D()
 	if c := C.faiss_Index_add_with_ids(
 		idx.idx,
@@ -148,8 +138,6 @@ func (idx *faissIndex) AddWithIDs(x []float32, xids []int64) error {
 func (idx *faissIndex) Search(x []float32, k int64) (
 	distances []float32, labels []int64, err error,
 ) {
-	runtime.LockOSThread()
-	defer runtime.UnlockOSThread()
 
 	n := len(x) / idx.D()
 	distances = make([]float32, int64(n)*k)
@@ -171,9 +159,6 @@ func (idx *faissIndex) Search(x []float32, k int64) (
 func (idx *faissIndex) SearchWithoutIDs(x []float32, k int64, exclude []int64) (
 	distances []float32, labels []int64, err error,
 ) {
-	runtime.LockOSThread()
-	defer runtime.UnlockOSThread()
-
 	if len(exclude) <= 0 {
 		return idx.Search(x, k)
 	}
@@ -211,9 +196,6 @@ func (idx *faissIndex) SearchWithoutIDs(x []float32, k int64, exclude []int64) (
 }
 
 func (idx *faissIndex) Reconstruct(key int64) (recons []float32, err error) {
-	runtime.LockOSThread()
-	defer runtime.UnlockOSThread()
-
 	rv := make([]float32, idx.D())
 	if c := C.faiss_Index_reconstruct(
 		idx.idx,
@@ -227,9 +209,6 @@ func (idx *faissIndex) Reconstruct(key int64) (recons []float32, err error) {
 }
 
 func (idx *faissIndex) ReconstructBatch(keys []int64, recons []float32) ([]float32, error) {
-	runtime.LockOSThread()
-	defer runtime.UnlockOSThread()
-
 	var err error
 	n := int64(len(keys))
 	if c := C.faiss_Index_reconstruct_batch(
@@ -252,9 +231,6 @@ func (i *IndexImpl) MergeFrom(other Index, add_id int64) error {
 }
 
 func (idx *faissIndex) MergeFrom(other Index, add_id int64) (err error) {
-	runtime.LockOSThread()
-	defer runtime.UnlockOSThread()
-
 	otherIdx, ok := other.(*faissIndex)
 	if !ok {
 		return fmt.Errorf("merge api not supported")
@@ -274,9 +250,6 @@ func (idx *faissIndex) MergeFrom(other Index, add_id int64) (err error) {
 func (idx *faissIndex) RangeSearch(x []float32, radius float32) (
 	*RangeSearchResult, error,
 ) {
-	runtime.LockOSThread()
-	defer runtime.UnlockOSThread()
-
 	n := len(x) / idx.D()
 	var rsr *C.FaissRangeSearchResult
 	if c := C.faiss_RangeSearchResult_new(&rsr, C.idx_t(n)); c != 0 {
@@ -295,9 +268,6 @@ func (idx *faissIndex) RangeSearch(x []float32, radius float32) (
 }
 
 func (idx *faissIndex) Reset() error {
-	runtime.LockOSThread()
-	defer runtime.UnlockOSThread()
-
 	if c := C.faiss_Index_reset(idx.idx); c != 0 {
 		return getLastError()
 	}
@@ -305,9 +275,6 @@ func (idx *faissIndex) Reset() error {
 }
 
 func (idx *faissIndex) RemoveIDs(sel *IDSelector) (int, error) {
-	runtime.LockOSThread()
-	defer runtime.UnlockOSThread()
-
 	var nRemoved C.size_t
 	if c := C.faiss_Index_remove_ids(idx.idx, sel.sel, &nRemoved); c != 0 {
 		return 0, getLastError()
@@ -364,9 +331,6 @@ type IndexImpl struct {
 // IndexFactory builds a composite index.
 // description is a comma-separated list of components.
 func IndexFactory(d int, description string, metric int) (*IndexImpl, error) {
-	runtime.LockOSThread()
-	defer runtime.UnlockOSThread()
-
 	cdesc := C.CString(description)
 	defer C.free(unsafe.Pointer(cdesc))
 	var idx faissIndex

--- a/index_io.go
+++ b/index_io.go
@@ -8,7 +8,6 @@ package faiss
 */
 import "C"
 import (
-	"runtime"
 	"unsafe"
 )
 
@@ -23,9 +22,6 @@ func WriteIndex(idx Index, filename string) error {
 }
 
 func WriteIndexIntoBuffer(idx Index) ([]byte, error) {
-	runtime.LockOSThread()
-	defer runtime.UnlockOSThread()
-
 	// the values to be returned by the faiss APIs
 	tempBuf := (*C.uchar)(C.malloc(C.size_t(0)))
 	bufSize := C.size_t(0)
@@ -82,9 +78,6 @@ func WriteIndexIntoBuffer(idx Index) ([]byte, error) {
 }
 
 func ReadIndexFromBuffer(buf []byte, ioflags int) (*IndexImpl, error) {
-	runtime.LockOSThread()
-	defer runtime.UnlockOSThread()
-
 	ptr := (*C.uchar)(unsafe.Pointer(&buf[0]))
 	size := C.size_t(len(buf))
 

--- a/index_ivf.go
+++ b/index_ivf.go
@@ -10,12 +10,9 @@ package faiss
 import "C"
 import (
 	"fmt"
-	"runtime"
 )
 
 func (idx *IndexImpl) SetDirectMap(mapType int) (err error) {
-	runtime.LockOSThread()
-	defer runtime.UnlockOSThread()
 
 	ivfPtr := C.faiss_IndexIVF_cast(idx.cPtr())
 	if ivfPtr == nil {
@@ -31,8 +28,6 @@ func (idx *IndexImpl) SetDirectMap(mapType int) (err error) {
 }
 
 func (idx *IndexImpl) GetSubIndex() (*IndexImpl, error) {
-	runtime.LockOSThread()
-	defer runtime.UnlockOSThread()
 
 	ptr := C.faiss_IndexIDMap2_cast(idx.cPtr())
 	if ptr == nil {

--- a/selector.go
+++ b/selector.go
@@ -4,7 +4,6 @@ package faiss
 #include <faiss/c_api/impl/AuxIndexStructures_c.h>
 */
 import "C"
-import "runtime"
 
 // IDSelector represents a set of IDs to remove.
 type IDSelector struct {
@@ -29,9 +28,6 @@ func (s *IDSelectorBatch) Delete() {
 
 // NewIDSelectorRange creates a selector that removes IDs on [imin, imax).
 func NewIDSelectorRange(imin, imax int64) (*IDSelector, error) {
-	runtime.LockOSThread()
-	defer runtime.UnlockOSThread()
-
 	var sel *C.FaissIDSelectorRange
 	c := C.faiss_IDSelectorRange_new(&sel, C.idx_t(imin), C.idx_t(imax))
 	if c != 0 {
@@ -42,9 +38,6 @@ func NewIDSelectorRange(imin, imax int64) (*IDSelector, error) {
 
 // NewIDSelectorBatch creates a new batch selector.
 func NewIDSelectorBatch(indices []int64) (*IDSelector, error) {
-	runtime.LockOSThread()
-	defer runtime.UnlockOSThread()
-
 	var sel *C.FaissIDSelectorBatch
 	if c := C.faiss_IDSelectorBatch_new(
 		&sel,
@@ -59,9 +52,6 @@ func NewIDSelectorBatch(indices []int64) (*IDSelector, error) {
 // NewIDSelectorNot creates a new Not selector, wrapped arround a
 // batch selector, with the IDs in 'exclude'.
 func NewIDSelectorNot(exclude []int64) (*IDSelectorBatch, error) {
-	runtime.LockOSThread()
-	defer runtime.UnlockOSThread()
-
 	batchSelector, err := NewIDSelectorBatch(exclude)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
- Locking the OS thread could lead to incoming goroutines creating new ones instead of allowing the scheduler from context switching an existing thread from the OS thread pool.
- Would require an alternate method for faiss exception handling in the error path which will be introduced in an seperate PR.