### PR TITLE
MB-62221: Fix platform specific behaviour

### DIFF
--- a/index_io.go
+++ b/index_io.go
@@ -23,7 +23,7 @@ func WriteIndex(idx Index, filename string) error {
 
 func WriteIndexIntoBuffer(idx Index) ([]byte, error) {
 	// the values to be returned by the faiss APIs
-	tempBuf := (*C.uchar)(C.malloc(C.size_t(0)))
+	tempBuf := (*C.uchar)(nil)
 	bufSize := C.size_t(0)
 
 	if c := C.faiss_write_index_buf(


### PR DESCRIPTION
- The code currently uses the malloc(0) function to create a null pointer variable, which would then be assigned a buffer on the C side.
- According to the C standard, malloc(0) leads to unspecified behavior and is platform-dependent.
- A simple nil assignment would be sufficient to achieve the same result without incurring platform-dependent behaviour.