### PR TITLE
MB-62221: Defer freeing the buffer to C

### DIFF
--- a/index_io.go
+++ b/index_io.go
@@ -31,7 +31,7 @@ func WriteIndexIntoBuffer(idx Index) ([]byte, error) {
 		&bufSize,
 		&tempBuf,
 	); c != 0 {
-		C.free(unsafe.Pointer(tempBuf))
+		faiss_free_buf(&tempBuf)
 		return nil, getLastError()
 	}
 
@@ -70,7 +70,7 @@ func WriteIndexIntoBuffer(idx Index) ([]byte, error) {
 
 	// safe to free the c memory allocated while serializing the index;
 	// rv is from go runtime - so different address space altogether
-	C.free(unsafe.Pointer(tempBuf))
+	faiss_free_buf(&tempBuf)
 	// p.s: no need to free "val" since the underlying memory is same as tempBuf (deferred free)
 	val = nil
 

--- a/index_io.go
+++ b/index_io.go
@@ -31,7 +31,7 @@ func WriteIndexIntoBuffer(idx Index) ([]byte, error) {
 		&bufSize,
 		&tempBuf,
 	); c != 0 {
-		faiss_free_buf(&tempBuf)
+		C.faiss_free_buf(&tempBuf)
 		return nil, getLastError()
 	}
 
@@ -70,7 +70,7 @@ func WriteIndexIntoBuffer(idx Index) ([]byte, error) {
 
 	// safe to free the c memory allocated while serializing the index;
 	// rv is from go runtime - so different address space altogether
-	faiss_free_buf(&tempBuf)
+	C.faiss_free_buf(&tempBuf)
 	// p.s: no need to free "val" since the underlying memory is same as tempBuf (deferred free)
 	val = nil
 

--- a/index_io.go
+++ b/index_io.go
@@ -68,9 +68,11 @@ func WriteIndexIntoBuffer(idx Index) ([]byte, error) {
 	// cheaper.
 	copy(rv, val)
 
-	// safe to free the c memory allocated while serializing the index;
+	// safe to free the c memory allocated (tempBuf) while serializing the index (must be done
+	// within C runtime for it was allocated there);
 	// rv is from go runtime - so different address space altogether
 	C.faiss_free_buf(&tempBuf)
+
 	// p.s: no need to free "val" since the underlying memory is same as tempBuf (deferred free)
 	val = nil
 


### PR DESCRIPTION
- The CGO runtime in Go is designed to use the allocator employed by the C environment, which is jemalloc. 
- On Linux, this integration works correctly due to the process's inherent method of searching for undefined symbols within the linked .so files. However, on Windows, this behavior does not occur as expected. 
- Consequently, the CGO runtime inadvertently utilizes glibc's free method to deallocate memory that was initially allocated by jemalloc, leading to a crash.