### PR TITLE
Mb 61889: support search with params

### DIFF
--- a/search_params.go
+++ b/search_params.go
@@ -1,0 +1,99 @@
+package faiss
+
+/*
+#include <faiss/c_api/Index_c.h>
+#include <faiss/c_api/IndexIVF_c.h>
+#include <faiss/c_api/impl/AuxIndexStructures_c.h>
+*/
+import "C"
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type SearchParams struct {
+	sp *C.FaissSearchParameters
+}
+
+// Delete frees the memory associated with s.
+func (s *SearchParams) Delete() {
+	if s == nil || s.sp == nil {
+		return
+	}
+	C.faiss_SearchParameters_free(s.sp)
+}
+
+type searchParamsIVF struct {
+	NprobePct   float32 `json:"ivf_nprobe_pct,omitempty"`
+	MaxCodesPct float32 `json:"ivf_max_codes_pct,omitempty"`
+}
+
+func (s *searchParamsIVF) Validate() error {
+	if s.NprobePct < 0 || s.NprobePct > 100 {
+		return fmt.Errorf("invalid IVF search params, ivf_nprobe_pct:%v, "+
+			"should be in range [0, 100]", s.NprobePct)
+	}
+
+	if s.MaxCodesPct < 0 || s.MaxCodesPct > 100 {
+		return fmt.Errorf("invalid IVF search params, ivf_max_codes_pct:%v, "+
+			"should be in range [0, 100]", s.MaxCodesPct)
+	}
+
+	return nil
+}
+
+// Always return a valid SearchParams object,
+// thus caller must clean up the object
+// by invoking Delete() method, even if an error is returned.
+func NewSearchParams(idx Index, params json.RawMessage, sel *C.FaissIDSelector,
+) (*SearchParams, error) {
+	rv := &SearchParams{}
+	if c := C.faiss_SearchParameters_new(&rv.sp, sel); c != 0 {
+		return rv, fmt.Errorf("failed to create faiss search params")
+	}
+
+	// # check if the index is IVF and set the search params
+	if ivfIdx := C.faiss_IndexIVF_cast(idx.cPtr()); ivfIdx != nil {
+		rv.sp = C.faiss_SearchParametersIVF_cast(rv.sp)
+		if len(params) == 0 {
+			return rv, nil
+		}
+
+		var ivfParams searchParamsIVF
+		if err := json.Unmarshal(params, &ivfParams); err != nil {
+			return rv, fmt.Errorf("failed to unmarshal IVF search params, "+
+				"err:%v", err)
+		}
+		if err := ivfParams.Validate(); err != nil {
+			return rv, err
+		}
+
+		var nprobe, maxCodes int
+
+		if ivfParams.NprobePct > 0 {
+			nlist := float32(C.faiss_IndexIVF_nlist(ivfIdx))
+			nprobe = int(nlist * (ivfParams.NprobePct / 100))
+		} else {
+			// It's important to set nprobe to the value decided at the time of
+			// index creation. Otherwise, nprobe will be set to the default
+			// value of 1.
+			nprobe = int(C.faiss_IndexIVF_nprobe(ivfIdx))
+		}
+
+		if ivfParams.MaxCodesPct > 0 {
+			nvecs := C.faiss_Index_ntotal(idx.cPtr())
+			maxCodes = int(float32(nvecs) * (ivfParams.MaxCodesPct / 100))
+		} // else, maxCodes will be set to the default value of 0, which means no limit
+
+		if c := C.faiss_SearchParametersIVF_new_with(
+			&rv.sp,
+			sel,
+			C.size_t(nprobe),
+			C.size_t(maxCodes),
+		); c != 0 {
+			return rv, fmt.Errorf("failed to create faiss IVF search params")
+		}
+	}
+
+	return rv, nil
+}

--- a/selector.go
+++ b/selector.go
@@ -12,6 +12,10 @@ type IDSelector struct {
 
 // Delete frees the memory associated with s.
 func (s *IDSelector) Delete() {
+	if s == nil || s.sel == nil {
+		return
+	}
+
 	C.faiss_IDSelector_free(s.sel)
 }
 
@@ -22,8 +26,16 @@ type IDSelectorBatch struct {
 
 // Delete frees the memory associated with s.
 func (s *IDSelectorBatch) Delete() {
-	C.faiss_IDSelector_free(s.sel)
-	C.faiss_IDSelector_free(s.batchSel)
+	if s == nil {
+		return
+	}
+
+	if s.sel != nil {
+		C.faiss_IDSelector_free(s.sel)
+	}
+	if s.batchSel != nil {
+		C.faiss_IDSelector_free(s.batchSel)
+	}
 }
 
 // NewIDSelectorRange creates a selector that removes IDs on [imin, imax).
@@ -62,6 +74,7 @@ func NewIDSelectorNot(exclude []int64) (*IDSelectorBatch, error) {
 		&sel,
 		batchSelector.sel,
 	); c != 0 {
+		batchSelector.Delete()
 		return nil, getLastError()
 	}
 	return &IDSelectorBatch{sel: (*C.FaissIDSelector)(sel), batchSel: batchSelector.sel}, nil


### PR DESCRIPTION
+ update SearchWithoutIDs() method to accept index specific search
    parameters.
+ using this, user can control latency vs recall tradeoff.

BUG_FIX

Prior to this change, SearchWithoutIDs() was using
faiss_SearchParametersIVF_new_with_sel() to create params,
with an intent of only tweaking selector param, without
affecting "nprobe".
And then was calling faiss_Index_search_with_params() to perform search.

+ But since, the value of params->nprobe wasn't provided explicitly,
    it was set to default (=1)
+ During IVF Search, params->nprobe take precedence over the value set during
    index creation time (this->nprobe)
+ Because of this, during search, we were unintentionally using nprobe=1

FIX:
During params creation, explicity set the value of nprobe to the
value chosen at the time of index creation.