### PR TITLE
MB-62230 - Pre-filtering support for kNN 

### DIFF
--- a/index.go
+++ b/index.go
@@ -52,6 +52,9 @@ type Index interface {
 	SearchWithoutIDs(x []float32, k int64, exclude []int64, params json.RawMessage) (distances []float32,
 		labels []int64, err error)
 
+	SearchWithIDs(x []float32, k int64, include []int64, params json.RawMessage) (distances []float32,
+		labels []int64, err error)
+
 	Reconstruct(key int64) ([]float32, error)
 
 	ReconstructBatch(keys []int64, recons []float32) ([]float32, error)
@@ -182,6 +185,25 @@ func (idx *faissIndex) SearchWithoutIDs(x []float32, k int64, exclude []int64, p
 
 	distances, labels, err = idx.searchWithParams(x, k, searchParams.sp)
 
+	return
+}
+
+func (idx *faissIndex) SearchWithIDs(x []float32, k int64, include []int64,
+	params json.RawMessage) (distances []float32, labels []int64, err error,
+) {
+	includeSelector, err := NewIDSelectorBatch(include)
+	defer includeSelector.Delete()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	searchParams, err := NewSearchParams(idx, params, includeSelector.sel)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer searchParams.Delete()
+
+	distances, labels, err = idx.searchWithParams(x, k, searchParams.sp)
 	return
 }
 

--- a/index.go
+++ b/index.go
@@ -192,10 +192,10 @@ func (idx *faissIndex) SearchWithIDs(x []float32, k int64, include []int64,
 	params json.RawMessage) (distances []float32, labels []int64, err error,
 ) {
 	includeSelector, err := NewIDSelectorBatch(include)
-	defer includeSelector.Delete()
 	if err != nil {
 		return nil, nil, err
 	}
+	defer includeSelector.Delete()
 
 	searchParams, err := NewSearchParams(idx, params, includeSelector.sel)
 	if err != nil {

--- a/search_params.go
+++ b/search_params.go
@@ -55,17 +55,19 @@ func NewSearchParams(idx Index, params json.RawMessage, sel *C.FaissIDSelector,
 	// # check if the index is IVF and set the search params
 	if ivfIdx := C.faiss_IndexIVF_cast(idx.cPtr()); ivfIdx != nil {
 		rv.sp = C.faiss_SearchParametersIVF_cast(rv.sp)
-		if len(params) == 0 {
+		if len(params) == 0 && sel == nil {
 			return rv, nil
 		}
 
 		var ivfParams searchParamsIVF
-		if err := json.Unmarshal(params, &ivfParams); err != nil {
-			return rv, fmt.Errorf("failed to unmarshal IVF search params, "+
-				"err:%v", err)
-		}
-		if err := ivfParams.Validate(); err != nil {
-			return rv, err
+		if len(params) > 0 {
+			if err := json.Unmarshal(params, &ivfParams); err != nil {
+				return rv, fmt.Errorf("failed to unmarshal IVF search params, "+
+					"err:%v", err)
+			}
+			if err := ivfParams.Validate(); err != nil {
+				return rv, err
+			}
 		}
 
 		var nprobe, maxCodes int


### PR DESCRIPTION
Adds a method, SearchWithIDs() which limits the search to only the IDs part of the inclusion list.