### PR TITLE
MB-61889: Address corner case with ivf_nprobe_pct

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/blevesearch/go-faiss
 
-go 1.19
+go 1.21

--- a/search_params.go
+++ b/search_params.go
@@ -72,12 +72,9 @@ func NewSearchParams(idx Index, params json.RawMessage, sel *C.FaissIDSelector,
 
 		if ivfParams.NprobePct > 0 {
 			nlist := float32(C.faiss_IndexIVF_nlist(ivfIdx))
-			nprobe = int(nlist * (ivfParams.NprobePct / 100))
-			if nprobe == 0 {
-				// in the situation when the calculated nprobe happens to be
-				// between 0 and 1, we'll round it up.
-				nprobe = 1
-			}
+			// in the situation when the calculated nprobe happens to be
+			// between 0 and 1, we'll round it up.
+			nprobe = max(int(nlist * (ivfParams.NprobePct / 100)), 1)
 		} else {
 			// it's important to set nprobe to the value decided at the time of
 			// index creation. Otherwise, nprobe will be set to the default


### PR DESCRIPTION
+ With certain cluster counts within centroid indexes, a very
  low value for ivf_nprobe_pct can cause nprobe to be rounded
  down to 0, which would result in this error ..
```
Error in virtual void faiss::IndexIVF::search(faiss::idx_t, const float*, faiss::idx_t, float*,
faiss::idx_t*, const faiss::SearchParameters*) const at /home/couchbase/.../faiss/faiss/IndexIVF.cpp:310:
    Error: 'nprobe > 0' failed
```
+ In this event, we should be rounding up nprobe to 1 instead.