### PR TITLE
MB-62230 - Functions to optimize pre-filtered kNN.

### DIFF
--- a/index.go
+++ b/index.go
@@ -201,7 +201,7 @@ func (idx *faissIndex) SearchClustersFromIVFIndex(include, eligibleCentroidIDs [
 		Nvecs: len(include),
 	}
 
-	searchParams, err := NewIVFSearchParams(idx, params, includeSelector.sel, tempParams)
+	searchParams, err := NewSearchParamsIVF(idx, params, includeSelector.sel, tempParams)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/index.go
+++ b/index.go
@@ -65,7 +65,7 @@ type Index interface {
 		labels []int64, err error)
 
 	// Applicable only to IVF indexes: Search clusters whose IDs are in eligibleCentroidIDs
-	SearchClusters(include, eligibleCentroidIDs []int64, minEligibleCentroids int,
+	SearchClustersFromIVFIndex(include, eligibleCentroidIDs []int64, minEligibleCentroids int,
 		k int64, x, centroidDis []float32, params json.RawMessage) ([]float32, []int64, error)
 
 	Reconstruct(key int64) ([]float32, error)
@@ -158,7 +158,7 @@ func (idx *faissIndex) ObtainClusterToVecIDsFromIVFIndex() (map[int64][]int64, e
 	return clusterVectorIDMap, nil
 }
 
-func (idx *faissIndex) SearchClusters(include, eligibleCentroidIDs []int64,
+func (idx *faissIndex) SearchClustersFromIVFIndex(include, eligibleCentroidIDs []int64,
 	minEligibleCentroids int, k int64, x, centroidDis []float32,
 	params json.RawMessage) ([]float32, []int64, error) {
 	// Applies only to IVF indexes.

--- a/index_ivf.go
+++ b/index_ivf.go
@@ -51,3 +51,11 @@ func (idx *IndexImpl) SetNProbe(nprobe int32) {
 	}
 	C.faiss_IndexIVF_set_nprobe(ivfPtr, C.size_t(nprobe))
 }
+
+func (idx *IndexImpl) GetNProbe() int32 {
+	ivfPtr := C.faiss_IndexIVF_cast(idx.cPtr())
+	if ivfPtr == nil {
+		return 0
+	}
+	return int32(C.faiss_IndexIVF_nprobe(ivfPtr))
+}

--- a/search_params.go
+++ b/search_params.go
@@ -46,7 +46,7 @@ func (s *searchParamsIVF) Validate() error {
 // thus caller must clean up the object
 // by invoking Delete() method, even if an error is returned.
 func NewSearchParams(idx Index, params json.RawMessage, sel *C.FaissIDSelector,
-) (*SearchParams, error) {
+	nprobe int) (*SearchParams, error) {
 	rv := &SearchParams{}
 	if c := C.faiss_SearchParameters_new(&rv.sp, sel); c != 0 {
 		return rv, fmt.Errorf("failed to create faiss search params")
@@ -76,7 +76,7 @@ func NewSearchParams(idx Index, params json.RawMessage, sel *C.FaissIDSelector,
 			nlist := float32(C.faiss_IndexIVF_nlist(ivfIdx))
 			// in the situation when the calculated nprobe happens to be
 			// between 0 and 1, we'll round it up.
-			nprobe = max(int(nlist * (ivfParams.NprobePct / 100)), 1)
+			nprobe = max(int(nlist*(ivfParams.NprobePct/100)), 1)
 		} else {
 			// it's important to set nprobe to the value decided at the time of
 			// index creation. Otherwise, nprobe will be set to the default

--- a/search_params.go
+++ b/search_params.go
@@ -28,6 +28,13 @@ type searchParamsIVF struct {
 	MaxCodesPct float32 `json:"ivf_max_codes_pct,omitempty"`
 }
 
+// IVF Parameters used to override the defaults for a specific query.
+type tempSearchParamsIVF struct {
+	Nprobe int `json:"ivf_nprobe,omitempty"`
+	Nlist  int `json:"ivf_nlist,omitempty"`
+	Nvecs  int `json:"ivf_nvecs,omitempty"`
+}
+
 func (s *searchParamsIVF) Validate() error {
 	if s.NprobePct < 0 || s.NprobePct > 100 {
 		return fmt.Errorf("invalid IVF search params, ivf_nprobe_pct:%v, "+
@@ -42,11 +49,16 @@ func (s *searchParamsIVF) Validate() error {
 	return nil
 }
 
+func GetNProbeFromSearchParams(params *SearchParams) int32 {
+	nprobe := C.faiss_SearchParametersIVF_nprobe(params.sp)
+	return int32(nprobe)
+}
+
 // Always return a valid SearchParams object,
 // thus caller must clean up the object
 // by invoking Delete() method, even if an error is returned.
 func NewSearchParams(idx Index, params json.RawMessage, sel *C.FaissIDSelector,
-	nprobe int) (*SearchParams, error) {
+	temporaryIndexParams json.RawMessage) (*SearchParams, error) {
 	rv := &SearchParams{}
 	if c := C.faiss_SearchParameters_new(&rv.sp, sel); c != 0 {
 		return rv, fmt.Errorf("failed to create faiss search params")
@@ -55,7 +67,7 @@ func NewSearchParams(idx Index, params json.RawMessage, sel *C.FaissIDSelector,
 	// check if the index is IVF and set the search params
 	if ivfIdx := C.faiss_IndexIVF_cast(idx.cPtr()); ivfIdx != nil {
 		rv.sp = C.faiss_SearchParametersIVF_cast(rv.sp)
-		if len(params) == 0 && sel == nil {
+		if len(temporaryIndexParams) == 0 && len(params) == 0 && sel == nil {
 			return rv, nil
 		}
 
@@ -70,22 +82,39 @@ func NewSearchParams(idx Index, params json.RawMessage, sel *C.FaissIDSelector,
 			}
 		}
 
-		var nprobe, maxCodes int
+		var nprobe, maxCodes, nlist int
+		nlist = int(C.faiss_IndexIVF_nlist(ivfIdx))
+		// It's important to set nprobe to the value decided at the time of
+		// index creation. Otherwise, nprobe will be set to the default
+		// value of 1.
+		nprobe = int(C.faiss_IndexIVF_nprobe(ivfIdx))
+
+		nvecs := idx.Ntotal()
+
+		var tempIVFParams tempSearchParamsIVF
+		if len(temporaryIndexParams) > 0 {
+			if err := json.Unmarshal(temporaryIndexParams, &tempIVFParams); err != nil {
+				return rv, fmt.Errorf("failed to unmarshal temporary IVF search "+
+					"params, err:%v", err)
+			}
+			if tempIVFParams.Nvecs > 0 {
+				nvecs = int64(tempIVFParams.Nvecs)
+			}
+			if tempIVFParams.Nlist > 0 {
+				nlist = tempIVFParams.Nlist
+			}
+			if tempIVFParams.Nprobe > 0 {
+				nprobe = tempIVFParams.Nprobe
+			}
+		}
 
 		if ivfParams.NprobePct > 0 {
-			nlist := float32(C.faiss_IndexIVF_nlist(ivfIdx))
 			// in the situation when the calculated nprobe happens to be
 			// between 0 and 1, we'll round it up.
-			nprobe = max(int(nlist*(ivfParams.NprobePct/100)), 1)
-		} else {
-			// it's important to set nprobe to the value decided at the time of
-			// index creation. Otherwise, nprobe will be set to the default
-			// value of 1.
-			nprobe = int(C.faiss_IndexIVF_nprobe(ivfIdx))
+			nprobe = max(int(float32(nlist)*(ivfParams.NprobePct/100)), 1)
 		}
 
 		if ivfParams.MaxCodesPct > 0 {
-			nvecs := C.faiss_Index_ntotal(idx.cPtr())
 			maxCodes = int(float32(nvecs) * (ivfParams.MaxCodesPct / 100))
 		} // else, maxCodes will be set to the default value of 0, which means no limit
 

--- a/search_params.go
+++ b/search_params.go
@@ -28,8 +28,10 @@ type searchParamsIVF struct {
 	MaxCodesPct float32 `json:"ivf_max_codes_pct,omitempty"`
 }
 
-// IVF Parameters used to override the defaults for a specific query.
-type tempSearchParamsIVF struct {
+// IVF Parameters used to override the index-time defaults for a specific query.
+// Serve as the 'new' defaults for this query, unless overridden by search-time
+// params.
+type defaultSearchParamsIVF struct {
 	Nprobe int `json:"ivf_nprobe,omitempty"`
 	Nlist  int `json:"ivf_nlist,omitempty"`
 	Nvecs  int `json:"ivf_nvecs,omitempty"`
@@ -53,11 +55,71 @@ func getNProbeFromSearchParams(params *SearchParams) int32 {
 	return int32(C.faiss_SearchParametersIVF_nprobe(params.sp))
 }
 
+func NewIVFSearchParams(idx Index, params json.RawMessage, sel *C.FaissIDSelector,
+	defaultParams defaultSearchParamsIVF) (*SearchParams, error) {
+	rv := &SearchParams{}
+	if ivfIdx := C.faiss_IndexIVF_cast(idx.cPtr()); ivfIdx != nil {
+		rv.sp = C.faiss_SearchParametersIVF_cast(rv.sp)
+		if len(params) == 0 && sel == nil {
+			return rv, nil
+		}
+
+		var nprobe, maxCodes, nlist int
+		nlist = int(C.faiss_IndexIVF_nlist(ivfIdx))
+		// It's important to set nprobe to the value decided at the time of
+		// index creation. Otherwise, nprobe will be set to the default
+		// value of 1.
+		nprobe = int(C.faiss_IndexIVF_nprobe(ivfIdx))
+
+		nvecs := idx.Ntotal()
+		if defaultParams.Nvecs > 0 {
+			nvecs = int64(defaultParams.Nvecs)
+		}
+		if defaultParams.Nlist > 0 {
+			nlist = defaultParams.Nlist
+		}
+		if defaultParams.Nprobe > 0 {
+			nprobe = defaultParams.Nprobe
+		}
+
+		var ivfParams searchParamsIVF
+		if len(params) > 0 {
+			if err := json.Unmarshal(params, &ivfParams); err != nil {
+				return rv, fmt.Errorf("failed to unmarshal IVF search params, "+
+					"err:%v", err)
+			}
+			if err := ivfParams.Validate(); err != nil {
+				return rv, err
+			}
+		}
+
+		if ivfParams.NprobePct > 0 {
+			// in the situation when the calculated nprobe happens to be
+			// between 0 and 1, we'll round it up.
+			nprobe = max(int(float32(nlist)*(ivfParams.NprobePct/100)), 1)
+		}
+
+		if ivfParams.MaxCodesPct > 0 {
+			maxCodes = int(float32(nvecs) * (ivfParams.MaxCodesPct / 100))
+		} // else, maxCodes will be set to the default value of 0, which means no limit
+
+		if c := C.faiss_SearchParametersIVF_new_with(
+			&rv.sp,
+			sel,
+			C.size_t(nprobe),
+			C.size_t(maxCodes),
+		); c != 0 {
+			return rv, fmt.Errorf("failed to create faiss IVF search params")
+		}
+	}
+	return rv, nil
+}
+
 // Always return a valid SearchParams object,
 // thus caller must clean up the object
 // by invoking Delete() method, even if an error is returned.
 func NewSearchParams(idx Index, params json.RawMessage, sel *C.FaissIDSelector,
-	temporaryIndexParams json.RawMessage) (*SearchParams, error) {
+) (*SearchParams, error) {
 	rv := &SearchParams{}
 	if c := C.faiss_SearchParameters_new(&rv.sp, sel); c != 0 {
 		return rv, fmt.Errorf("failed to create faiss search params")
@@ -66,7 +128,7 @@ func NewSearchParams(idx Index, params json.RawMessage, sel *C.FaissIDSelector,
 	// check if the index is IVF and set the search params
 	if ivfIdx := C.faiss_IndexIVF_cast(idx.cPtr()); ivfIdx != nil {
 		rv.sp = C.faiss_SearchParametersIVF_cast(rv.sp)
-		if len(temporaryIndexParams) == 0 && len(params) == 0 && sel == nil {
+		if len(params) == 0 && sel == nil {
 			return rv, nil
 		}
 
@@ -81,39 +143,22 @@ func NewSearchParams(idx Index, params json.RawMessage, sel *C.FaissIDSelector,
 			}
 		}
 
-		var nprobe, maxCodes, nlist int
-		nlist = int(C.faiss_IndexIVF_nlist(ivfIdx))
-		// It's important to set nprobe to the value decided at the time of
-		// index creation. Otherwise, nprobe will be set to the default
-		// value of 1.
-		nprobe = int(C.faiss_IndexIVF_nprobe(ivfIdx))
-
-		nvecs := idx.Ntotal()
-
-		var tempIVFParams tempSearchParamsIVF
-		if len(temporaryIndexParams) > 0 {
-			if err := json.Unmarshal(temporaryIndexParams, &tempIVFParams); err != nil {
-				return rv, fmt.Errorf("failed to unmarshal temporary IVF search "+
-					"params, err:%v", err)
-			}
-			if tempIVFParams.Nvecs > 0 {
-				nvecs = int64(tempIVFParams.Nvecs)
-			}
-			if tempIVFParams.Nlist > 0 {
-				nlist = tempIVFParams.Nlist
-			}
-			if tempIVFParams.Nprobe > 0 {
-				nprobe = tempIVFParams.Nprobe
-			}
-		}
+		var nprobe, maxCodes int
 
 		if ivfParams.NprobePct > 0 {
+			nlist := float32(C.faiss_IndexIVF_nlist(ivfIdx))
 			// in the situation when the calculated nprobe happens to be
 			// between 0 and 1, we'll round it up.
-			nprobe = max(int(float32(nlist)*(ivfParams.NprobePct/100)), 1)
+			nprobe = max(int(nlist*(ivfParams.NprobePct/100)), 1)
+		} else {
+			// it's important to set nprobe to the value decided at the time of
+			// index creation. Otherwise, nprobe will be set to the default
+			// value of 1.
+			nprobe = int(C.faiss_IndexIVF_nprobe(ivfIdx))
 		}
 
 		if ivfParams.MaxCodesPct > 0 {
+			nvecs := C.faiss_Index_ntotal(idx.cPtr())
 			maxCodes = int(float32(nvecs) * (ivfParams.MaxCodesPct / 100))
 		} // else, maxCodes will be set to the default value of 0, which means no limit
 

--- a/search_params.go
+++ b/search_params.go
@@ -55,7 +55,7 @@ func getNProbeFromSearchParams(params *SearchParams) int32 {
 	return int32(C.faiss_SearchParametersIVF_nprobe(params.sp))
 }
 
-func NewIVFSearchParams(idx Index, params json.RawMessage, sel *C.FaissIDSelector,
+func NewSearchParamsIVF(idx Index, params json.RawMessage, sel *C.FaissIDSelector,
 	defaultParams defaultSearchParamsIVF) (*SearchParams, error) {
 	rv := &SearchParams{}
 	if ivfIdx := C.faiss_IndexIVF_cast(idx.cPtr()); ivfIdx != nil {

--- a/search_params.go
+++ b/search_params.go
@@ -49,9 +49,8 @@ func (s *searchParamsIVF) Validate() error {
 	return nil
 }
 
-func GetNProbeFromSearchParams(params *SearchParams) int32 {
-	nprobe := C.faiss_SearchParametersIVF_nprobe(params.sp)
-	return int32(nprobe)
+func getNProbeFromSearchParams(params *SearchParams) int32 {
+	return int32(C.faiss_SearchParametersIVF_nprobe(params.sp))
 }
 
 // Always return a valid SearchParams object,

--- a/selector.go
+++ b/selector.go
@@ -61,7 +61,7 @@ func NewIDSelectorBatch(indices []int64) (*IDSelector, error) {
 	return &IDSelector{(*C.FaissIDSelector)(sel)}, nil
 }
 
-// NewIDSelectorNot creates a new Not selector, wrapped arround a
+// NewIDSelectorNot creates a new Not selector, wrapped around a
 // batch selector, with the IDs in 'exclude'.
 func NewIDSelectorNot(exclude []int64) (*IDSelectorBatch, error) {
 	batchSelector, err := NewIDSelectorBatch(exclude)

--- a/selector.go
+++ b/selector.go
@@ -19,13 +19,13 @@ func (s *IDSelector) Delete() {
 	C.faiss_IDSelector_free(s.sel)
 }
 
-type IDSelectorBatch struct {
+type IDSelectorNot struct {
 	sel      *C.FaissIDSelector
 	batchSel *C.FaissIDSelector
 }
 
 // Delete frees the memory associated with s.
-func (s *IDSelectorBatch) Delete() {
+func (s *IDSelectorNot) Delete() {
 	if s == nil {
 		return
 	}
@@ -63,7 +63,7 @@ func NewIDSelectorBatch(indices []int64) (*IDSelector, error) {
 
 // NewIDSelectorNot creates a new Not selector, wrapped around a
 // batch selector, with the IDs in 'exclude'.
-func NewIDSelectorNot(exclude []int64) (*IDSelectorBatch, error) {
+func NewIDSelectorNot(exclude []int64) (*IDSelectorNot, error) {
 	batchSelector, err := NewIDSelectorBatch(exclude)
 	if err != nil {
 		return nil, err
@@ -77,5 +77,5 @@ func NewIDSelectorNot(exclude []int64) (*IDSelectorBatch, error) {
 		batchSelector.Delete()
 		return nil, getLastError()
 	}
-	return &IDSelectorBatch{sel: (*C.FaissIDSelector)(sel), batchSel: batchSelector.sel}, nil
+	return &IDSelectorNot{sel: (*C.FaissIDSelector)(sel), batchSel: batchSelector.sel}, nil
 }


### PR DESCRIPTION
Adds functions for indexes to return - 
1. the cluster assignment(centroid-cluster vector mapping) for an IVF index.
2. the centroid IDs in an IVF index, along with their distances.
3. Search only specified clusters, identified by their centroid IDs.

Minor naming change - 
IDSelectorBatch was a misnomer for a negatory selector - renamed it to IDSelectorNot.