### PR TITLE
MB-64513: Removing modification of max codes based on filtered document size

### DIFF
--- a/search_params.go
+++ b/search_params.go
@@ -72,9 +72,6 @@ func NewSearchParamsIVF(idx Index, params json.RawMessage, sel *C.FaissIDSelecto
 		nprobe = int(C.faiss_IndexIVF_nprobe(ivfIdx))
 
 		nvecs := idx.Ntotal()
-		if defaultParams.Nvecs > 0 {
-			nvecs = int64(defaultParams.Nvecs)
-		}
 		if defaultParams.Nlist > 0 {
 			nlist = defaultParams.Nlist
 		}


### PR DESCRIPTION
Currently max codes is the number of scans performed at the faiss level. Without prefiltering, every single scan leads to a computation as well.

With prefiltering however, the logic is slightly different. Max codes is reduced from a percent of the total number of vectors to a percent of the filtered documents. This implies that we scan through max codes percent of the filtered vectors. Looking into the faiss code paths, this is not the case. We scan through max codes number of vectors and then apply the filtered vectors first before the distance computation. This means that max codes takes precedence over filtering and there is a very high possibility of not scanning the filtered vectors.

This fix removes the dependency between prefiltering and max codes by not reducing the max codes number from total vectors length to filtered vector length.