### PR TITLE
MB-65473: Refactor and Optimize Pre-Filtered Vector Search

### DIFF
--- a/index.go
+++ b/index.go
@@ -178,7 +178,8 @@ func (idx *faissIndex) ObtainClustersWithDistancesFromIVFIndex(x []float32, cent
 	}
 	defer includeSelector.Delete()
 
-	params, err := NewSearchParams(idx, json.RawMessage{}, includeSelector.Get())
+	params, err := NewSearchParams(idx, json.RawMessage{}, includeSelector.Get(), nil)
+	defer params.Delete()
 	if err != nil {
 		return nil, nil, err
 	}
@@ -202,7 +203,6 @@ func (idx *faissIndex) ObtainClustersWithDistancesFromIVFIndex(x []float32, cent
 func (idx *faissIndex) SearchClustersFromIVFIndex(selector Selector, nvecs int,
 	eligibleCentroidIDs []int64, minEligibleCentroids int, k int64, x,
 	centroidDis []float32, params json.RawMessage) ([]float32, []int64, error) {
-	defer selector.Delete()
 
 	tempParams := &defaultSearchParamsIVF{
 		Nlist: len(eligibleCentroidIDs),
@@ -212,8 +212,8 @@ func (idx *faissIndex) SearchClustersFromIVFIndex(selector Selector, nvecs int,
 		Nvecs:  nvecs,
 	}
 
-	searchParams, err := NewSearchParamsIVF(idx, params, selector.Get(),
-		tempParams)
+	searchParams, err := NewSearchParams(idx, params, selector.Get(), tempParams)
+	defer searchParams.Delete()
 	if err != nil {
 		return nil, nil, err
 	}
@@ -294,7 +294,7 @@ func (idx *faissIndex) SearchWithoutIDs(x []float32, k int64, exclude []int64, p
 		defer excludeSelector.Delete()
 	}
 
-	searchParams, err := NewSearchParams(idx, params, selector)
+	searchParams, err := NewSearchParams(idx, params, selector, nil)
 	defer searchParams.Delete()
 	if err != nil {
 		return nil, nil, err
@@ -314,11 +314,11 @@ func (idx *faissIndex) SearchWithIDs(x []float32, k int64, include []int64,
 	}
 	defer includeSelector.Delete()
 
-	searchParams, err := NewSearchParams(idx, params, includeSelector.Get())
+	searchParams, err := NewSearchParams(idx, params, includeSelector.Get(), nil)
+	defer searchParams.Delete()
 	if err != nil {
 		return nil, nil, err
 	}
-	defer searchParams.Delete()
 
 	distances, labels, err = idx.searchWithParams(x, k, searchParams.sp)
 	return

--- a/index.go
+++ b/index.go
@@ -188,10 +188,10 @@ func (idx *faissIndex) ObtainClustersWithDistancesFromIVFIndex(x []float32, cent
 	defer includeSelector.Delete()
 
 	params, err := NewSearchParams(idx, json.RawMessage{}, includeSelector.Get(), nil)
-	defer params.Delete()
 	if err != nil {
 		return nil, nil, err
 	}
+	defer params.Delete()
 
 	// Populate these with the centroids and their distances.
 	centroids := make([]int64, len(centroidIDs))
@@ -226,10 +226,10 @@ func (idx *faissIndex) SearchClustersFromIVFIndex(selector Selector,
 	}
 
 	searchParams, err := NewSearchParams(idx, params, selector.Get(), tempParams)
-	defer searchParams.Delete()
 	if err != nil {
 		return nil, nil, err
 	}
+	defer searchParams.Delete()
 
 	n := len(x) / idx.D()
 
@@ -308,10 +308,10 @@ func (idx *faissIndex) SearchWithoutIDs(x []float32, k int64, exclude []int64, p
 	}
 
 	searchParams, err := NewSearchParams(idx, params, selector, nil)
-	defer searchParams.Delete()
 	if err != nil {
 		return nil, nil, err
 	}
+	defer searchParams.Delete()
 
 	distances, labels, err = idx.searchWithParams(x, k, searchParams.sp)
 
@@ -328,10 +328,10 @@ func (idx *faissIndex) SearchWithIDs(x []float32, k int64, include []int64,
 	defer includeSelector.Delete()
 
 	searchParams, err := NewSearchParams(idx, params, includeSelector.Get(), nil)
-	defer searchParams.Delete()
 	if err != nil {
 		return nil, nil, err
 	}
+	defer searchParams.Delete()
 
 	distances, labels, err = idx.searchWithParams(x, k, searchParams.sp)
 	return

--- a/index.go
+++ b/index.go
@@ -47,8 +47,9 @@ type Index interface {
 	// Returns true if the index is an IVF index.
 	IsIVFIndex() bool
 
-	// CountVectorsPerCluster returns a map where the keys are cluster IDs
-	// and the values represent the count of input vectors that belong to each cluster.
+	// Applicable only to IVF indexes: Returns a map where the keys
+	// are cluster IDs and the values represent the count of input vectors that belong
+	// to each cluster.
 	// This method only considers the given vecIDs and does not account for all
 	// vectors in the index.
 	// Example:
@@ -56,7 +57,7 @@ type Index interface {
 	// - Vectors 1 and 2 belong to cluster 1
 	// - Vectors 3, 4, and 5 belong to cluster 2
 	// The output will be: map[1:2, 2:3]
-	CountVectorsPerCluster(vecIDs []int64) (map[int64]int64, error)
+	ObtainClusterVectorCountsFromIVFIndex(vecIDs []int64) (map[int64]int64, error)
 
 	// Applicable only to IVF indexes: Returns the centroid IDs in decreasing order
 	// of proximity to query 'x' and their distance from 'x'
@@ -150,7 +151,7 @@ func (idx *faissIndex) Add(x []float32) error {
 	return nil
 }
 
-func (idx *faissIndex) CountVectorsPerCluster(vecIDs []int64) (map[int64]int64, error) {
+func (idx *faissIndex) ObtainClusterVectorCountsFromIVFIndex(vecIDs []int64) (map[int64]int64, error) {
 	if !idx.IsIVFIndex() {
 		return nil, fmt.Errorf("index is not an IVF index")
 	}

--- a/index.go
+++ b/index.go
@@ -76,7 +76,7 @@ type Index interface {
 		labels []int64, err error)
 
 	// Applicable only to IVF indexes: Search clusters whose IDs are in eligibleCentroidIDs
-	SearchClustersFromIVFIndex(selector Selector, nvecs int, eligibleCentroidIDs []int64,
+	SearchClustersFromIVFIndex(selector Selector, eligibleCentroidIDs []int64,
 		minEligibleCentroids int, k int64, x, centroidDis []float32,
 		params json.RawMessage) ([]float32, []int64, error)
 
@@ -201,7 +201,7 @@ func (idx *faissIndex) ObtainClustersWithDistancesFromIVFIndex(x []float32, cent
 	return centroids, centroidDistances, nil
 }
 
-func (idx *faissIndex) SearchClustersFromIVFIndex(selector Selector, nvecs int,
+func (idx *faissIndex) SearchClustersFromIVFIndex(selector Selector,
 	eligibleCentroidIDs []int64, minEligibleCentroids int, k int64, x,
 	centroidDis []float32, params json.RawMessage) ([]float32, []int64, error) {
 
@@ -210,7 +210,6 @@ func (idx *faissIndex) SearchClustersFromIVFIndex(selector Selector, nvecs int,
 		// Have to override nprobe so that more clusters will be searched for this
 		// query, if required.
 		Nprobe: minEligibleCentroids,
-		Nvecs:  nvecs,
 	}
 
 	searchParams, err := NewSearchParams(idx, params, selector.Get(), tempParams)

--- a/index.go
+++ b/index.go
@@ -158,7 +158,7 @@ func (idx *faissIndex) ObtainClusterVectorCountsFromIVFIndex(vecIDs []int64) (ma
 	rv := make(map[int64]int64, len(vecIDs))
 	for _, vecID := range vecIDs {
 		clusterID := C.faiss_get_list_for_key(idx.idx, (C.idx_t)(vecID))
-		rv[int64(clusterID)] += 1
+		rv[int64(clusterID)]++
 	}
 	return rv, nil
 }

--- a/search_params.go
+++ b/search_params.go
@@ -77,9 +77,15 @@ func NewSearchParams(idx Index, params json.RawMessage, sel *C.FaissIDSelector,
 		nvecs = int(C.faiss_Index_ntotal(idx.cPtr()))
 
 		if defaultParams != nil {
-			nlist = defaultParams.Nlist
-			nprobe = defaultParams.Nprobe
-			nvecs = defaultParams.Nvecs
+			if defaultParams.Nlist > 0 {
+				nlist = defaultParams.Nlist
+			}
+			if defaultParams.Nprobe > 0 {
+				nprobe = defaultParams.Nprobe
+			}
+			if defaultParams.Nvecs > 0 {
+				nvecs = defaultParams.Nvecs
+			}
 		}
 
 		var ivfParams searchParamsIVF

--- a/search_params.go
+++ b/search_params.go
@@ -54,6 +54,9 @@ func getNProbeFromSearchParams(params *SearchParams) int32 {
 	return int32(C.faiss_SearchParametersIVF_nprobe(params.sp))
 }
 
+// Returns a valid SearchParams object,
+// thus caller must clean up the object
+// by invoking Delete() method.
 func NewSearchParams(idx Index, params json.RawMessage, sel *C.FaissIDSelector,
 	defaultParams *defaultSearchParamsIVF) (*SearchParams, error) {
 	rv := &SearchParams{}

--- a/search_params.go
+++ b/search_params.go
@@ -55,68 +55,11 @@ func getNProbeFromSearchParams(params *SearchParams) int32 {
 	return int32(C.faiss_SearchParametersIVF_nprobe(params.sp))
 }
 
-func NewSearchParamsIVF(idx Index, params json.RawMessage, sel *C.FaissIDSelector,
-	defaultParams *defaultSearchParamsIVF) (*SearchParams, error) {
-	rv := &SearchParams{}
-	if ivfIdx := C.faiss_IndexIVF_cast(idx.cPtr()); ivfIdx != nil {
-		rv.sp = C.faiss_SearchParametersIVF_cast(rv.sp)
-		if len(params) == 0 && sel == nil {
-			return rv, nil
-		}
-
-		var nprobe, maxCodes, nlist int
-		nlist = int(C.faiss_IndexIVF_nlist(ivfIdx))
-		// It's important to set nprobe to the value decided at the time of
-		// index creation. Otherwise, nprobe will be set to the default
-		// value of 1.
-		nprobe = int(C.faiss_IndexIVF_nprobe(ivfIdx))
-
-		nvecs := idx.Ntotal()
-		if defaultParams.Nlist > 0 {
-			nlist = defaultParams.Nlist
-		}
-		if defaultParams.Nprobe > 0 {
-			nprobe = defaultParams.Nprobe
-		}
-
-		var ivfParams searchParamsIVF
-		if len(params) > 0 {
-			if err := json.Unmarshal(params, &ivfParams); err != nil {
-				return rv, fmt.Errorf("failed to unmarshal IVF search params, "+
-					"err:%v", err)
-			}
-			if err := ivfParams.Validate(); err != nil {
-				return rv, err
-			}
-		}
-
-		if ivfParams.NprobePct > 0 {
-			// in the situation when the calculated nprobe happens to be
-			// between 0 and 1, we'll round it up.
-			nprobe = max(int(float32(nlist)*(ivfParams.NprobePct/100)), 1)
-		}
-
-		if ivfParams.MaxCodesPct > 0 {
-			maxCodes = int(float32(nvecs) * (ivfParams.MaxCodesPct / 100))
-		} // else, maxCodes will be set to the default value of 0, which means no limit
-
-		if c := C.faiss_SearchParametersIVF_new_with(
-			&rv.sp,
-			sel,
-			C.size_t(nprobe),
-			C.size_t(maxCodes),
-		); c != 0 {
-			return rv, fmt.Errorf("failed to create faiss IVF search params")
-		}
-	}
-	return rv, nil
-}
-
 // Always return a valid SearchParams object,
 // thus caller must clean up the object
 // by invoking Delete() method, even if an error is returned.
 func NewSearchParams(idx Index, params json.RawMessage, sel *C.FaissIDSelector,
-) (*SearchParams, error) {
+	defaultParams *defaultSearchParamsIVF) (*SearchParams, error) {
 	rv := &SearchParams{}
 	if c := C.faiss_SearchParameters_new(&rv.sp, sel); c != 0 {
 		return rv, fmt.Errorf("failed to create faiss search params")
@@ -128,6 +71,16 @@ func NewSearchParams(idx Index, params json.RawMessage, sel *C.FaissIDSelector,
 		if len(params) == 0 && sel == nil {
 			return rv, nil
 		}
+		var nlist, nprobe, nvecs, maxCodes int
+		nlist = int(C.faiss_IndexIVF_nlist(ivfIdx))
+		nprobe = int(C.faiss_IndexIVF_nprobe(ivfIdx))
+		nvecs = int(C.faiss_Index_ntotal(idx.cPtr()))
+
+		if defaultParams != nil {
+			nlist = defaultParams.Nlist
+			nprobe = defaultParams.Nprobe
+			nvecs = defaultParams.Nvecs
+		}
 
 		var ivfParams searchParamsIVF
 		if len(params) > 0 {
@@ -140,22 +93,10 @@ func NewSearchParams(idx Index, params json.RawMessage, sel *C.FaissIDSelector,
 			}
 		}
 
-		var nprobe, maxCodes int
-
 		if ivfParams.NprobePct > 0 {
-			nlist := float32(C.faiss_IndexIVF_nlist(ivfIdx))
-			// in the situation when the calculated nprobe happens to be
-			// between 0 and 1, we'll round it up.
-			nprobe = max(int(nlist*(ivfParams.NprobePct/100)), 1)
-		} else {
-			// it's important to set nprobe to the value decided at the time of
-			// index creation. Otherwise, nprobe will be set to the default
-			// value of 1.
-			nprobe = int(C.faiss_IndexIVF_nprobe(ivfIdx))
+			nprobe = max(int(float32(nlist)*(ivfParams.NprobePct/100)), 1)
 		}
-
 		if ivfParams.MaxCodesPct > 0 {
-			nvecs := C.faiss_Index_ntotal(idx.cPtr())
 			maxCodes = int(float32(nvecs) * (ivfParams.MaxCodesPct / 100))
 		} // else, maxCodes will be set to the default value of 0, which means no limit
 

--- a/search_params.go
+++ b/search_params.go
@@ -56,7 +56,7 @@ func getNProbeFromSearchParams(params *SearchParams) int32 {
 }
 
 func NewSearchParamsIVF(idx Index, params json.RawMessage, sel *C.FaissIDSelector,
-	defaultParams defaultSearchParamsIVF) (*SearchParams, error) {
+	defaultParams *defaultSearchParamsIVF) (*SearchParams, error) {
 	rv := &SearchParams{}
 	if ivfIdx := C.faiss_IndexIVF_cast(idx.cPtr()); ivfIdx != nil {
 		rv.sp = C.faiss_SearchParametersIVF_cast(rv.sp)


### PR DESCRIPTION
- Add `ObtainClusterVectorCountsFromIVFIndex` API to return cluster vector counts for given vector IDs.
- Refactor the `SearchClustersFromIVFIndex` API to remove the unused nvecs value and the Nvecs attribute from `defaultSearchParamsIVF`.
- Remove the NewSearchParamsIVF API and refactor `NewSearchParams` to accept `defaultSearchParamsIVF` instead.
- Requires https://github.com/blevesearch/faiss/pull/49