### PR TITLE
Add introspection methods to binary and float index classes

### DIFF
--- a/index_binary.go
+++ b/index_binary.go
@@ -22,6 +22,9 @@ type BinaryIndex interface {
 	// MetricType returns the metric type of the index.
 	MetricType() int
 
+	// Ntotal returns the total number of vectors currently stored in the index.
+	Ntotal() int64
+
 	// set the direct map type for IVF indexes.
 	// 0 for No Map
 	// 1 for Array
@@ -100,6 +103,10 @@ func (b *faissBinaryIndex) D() int {
 
 func (b *faissBinaryIndex) MetricType() int {
 	return int(C.faiss_IndexBinary_metric_type(b.bIdx))
+}
+
+func (b *faissBinaryIndex) Ntotal() int64 {
+	return int64(C.faiss_IndexBinary_ntotal(b.bIdx))
 }
 
 func (b *faissBinaryIndex) SetDirectMap(mapType int) (err error) {

--- a/index_binary.go
+++ b/index_binary.go
@@ -19,6 +19,9 @@ type BinaryIndex interface {
 	// D returns the dimension of the indexed vectors.
 	D() int
 
+	// MetricType returns the metric type of the index.
+	MetricType() int
+
 	// set the direct map type for IVF indexes.
 	// 0 for No Map
 	// 1 for Array
@@ -93,6 +96,10 @@ func (b *faissBinaryIndex) bPtr() *C.FaissIndexBinary {
 
 func (b *faissBinaryIndex) D() int {
 	return int(C.faiss_IndexBinary_d(b.bIdx))
+}
+
+func (b *faissBinaryIndex) MetricType() int {
+	return int(C.faiss_IndexBinary_metric_type(b.bIdx))
 }
 
 func (b *faissBinaryIndex) SetDirectMap(mapType int) (err error) {

--- a/index_ivf.go
+++ b/index_ivf.go
@@ -6,6 +6,7 @@ package faiss
 #include <faiss/c_api/Index_c.h>
 #include <faiss/c_api/IndexIVF_c.h>
 #include <faiss/c_api/IndexIVF_c_ex.h>
+#include <faiss/c_api/IndexScalarQuantizer_c.h>
 */
 import "C"
 import (
@@ -59,4 +60,9 @@ func (idx *IndexImpl) IVFParams() (nprobe, nlist int) {
 	}
 	return int(C.faiss_IndexIVF_nprobe(ivfPtr)),
 		int(C.faiss_IndexIVF_nlist(ivfPtr))
+}
+
+func (idx *IndexImpl) IsSQIndex() bool {
+	sqPtr := C.faiss_IndexScalarQuantizer_cast(idx.cPtr())
+	return sqPtr != nil
 }


### PR DESCRIPTION
- Added `MetricType()` to the `BinaryIndex` interface and its underlying `faissBinaryIndex` implementation via the FAISS C API.
- Added `IsSQIndex()` to `IndexImpl` to detect scalar quantizer indexes via a C-level cast.