### PR TITLE
MB-68591: Make the GPU sort unstable to load balance between GPUs better

### DIFF
--- a/gpu.go
+++ b/gpu.go
@@ -27,6 +27,7 @@ import "C"
 import (
 	"errors"
 	"fmt"
+	"math/rand"
 	"sort"
 	"sync"
 	"sync/atomic"
@@ -154,7 +155,12 @@ func (lb *gpuLoadBalancer) refresh() {
 		}
 	}
 
-	// sort descending by free memory so index 0 is the most appealing GPU.
+	// Shuffle first, then sort descending by free memory to make the
+	// sort as "unstable" as possible
+	// This is useful to add fairness between GPUs with the same memory 
+	rand.Shuffle(len(lb.scratchDevs), func(i, j int) {
+		lb.scratchDevs[i], lb.scratchDevs[j] = lb.scratchDevs[j], lb.scratchDevs[i]
+	})
 	sort.Slice(lb.scratchDevs, func(i, j int) bool {
 		return lb.freeMemory[lb.scratchDevs[i]] > lb.freeMemory[lb.scratchDevs[j]]
 	})

--- a/gpu.go
+++ b/gpu.go
@@ -161,6 +161,7 @@ func (lb *gpuLoadBalancer) refresh() {
 	rand.Shuffle(len(lb.scratchDevs), func(i, j int) {
 		lb.scratchDevs[i], lb.scratchDevs[j] = lb.scratchDevs[j], lb.scratchDevs[i]
 	})
+	// Sort in a descending order by free memory so index 0 is the most appealing GPU.
 	sort.Slice(lb.scratchDevs, func(i, j int) bool {
 		return lb.freeMemory[lb.scratchDevs[i]] > lb.freeMemory[lb.scratchDevs[j]]
 	})


### PR DESCRIPTION
Performs a random shuffle before sorting GPUs by memory in descending order. While `sort.Slice` does not use stable sorting, it still isn't random enough between sorts leading to certain GPUs being assigned more indexes than others. The shuffle makes the sort more "unstable".

Since the number of GPUs on a machine is typically less (at max 8), this will always a cheap operation.