### PR TITLE
Fix bugs with `SearchWithSelector`

### DIFF
--- a/index.go
+++ b/index.go
@@ -70,8 +70,10 @@ type Index interface {
 	// corresponding distances.
 	Search(x []float32, k int64) (distances []float32, labels []int64, err error)
 
-	SearchWithSelector(x []float32, k int64, sel Selector, params json.RawMessage) (distances []float32,
-		labels []int64, err error)
+	// SearchWithOptions performs a search with additional optional constraints.
+	// - Selector can be used to restrict the search to a subset of the indexed vectors based on their IDs.
+	// - params is a JSON object that can contain additional search parameters specific to the index type, such as IVF search parameters.
+	SearchWithOptions(x []float32, k int64, sel Selector, params json.RawMessage) (distances []float32, labels []int64, err error)
 
 	// Applicable only to IVF indexes: Search clusters whose IDs are in eligibleCentroidIDs
 	SearchClustersFromIVFIndex(eligibleCentroidIDs []int64, centroidDis []float32, centroidsToProbe int,
@@ -392,23 +394,11 @@ func (idx *faissIndex) Search(x []float32, k int64) (
 	return
 }
 
-// SearchWithoutIDs performs a search excluding the IDs specified in the exclude selector.
-func (idx *faissIndex) SearchWithSelector(x []float32, k int64, sel Selector, params json.RawMessage) (
-	distances []float32, labels []int64, err error,
-) {
-	if sel == nil {
-		return nil, nil, fmt.Errorf("SearchWithSelector requires a valid selector when params are provided")
+func (idx *faissIndex) SearchWithOptions(x []float32, k int64, sel Selector, params json.RawMessage) ([]float32, []int64, error) {
+	if sel == nil && params == nil {
+		return idx.Search(x, k)
 	}
-	// Create search parameters with the exclude selector.
-	searchParams, err := NewSearchParams(idx, params, sel, nil)
-	if err != nil {
-		return nil, nil, err
-	}
-	// cleanup the searchParams after use
-	defer searchParams.Delete()
-	// Perform the search with the specified parameters.
-	distances, labels, err = idx.searchWithParams(x, k, searchParams.sp)
-	return
+	return idx.searchWithParams(x, k, sel, params)
 }
 
 func (idx *faissIndex) Reconstruct(key int64) (recons []float32, err error) {
@@ -512,26 +502,30 @@ func (idx *faissIndex) Close() {
 	C.faiss_Index_free(idx.idx)
 }
 
-func (idx *faissIndex) searchWithParams(x []float32, k int64, searchParams *C.FaissSearchParameters) (
-	distances []float32, labels []int64, err error,
-) {
+func (idx *faissIndex) searchWithParams(x []float32, k int64, sel Selector, params json.RawMessage) ([]float32, []int64, error) {
+	// Build a search params object to contain either the selector, the additional params, or both.
+	searchParams, err := NewSearchParams(idx, params, sel, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer searchParams.Delete()
+
 	n := len(x) / idx.D()
-	distances = make([]float32, int64(n)*k)
-	labels = make([]int64, int64(n)*k)
+	distances := make([]float32, int64(n)*k)
+	labels := make([]int64, int64(n)*k)
 
 	if c := C.faiss_Index_search_with_params(
 		idx.idx,
 		C.idx_t(n),
 		(*C.float)(&x[0]),
 		C.idx_t(k),
-		searchParams,
+		searchParams.sp,
 		(*C.float)(&distances[0]),
 		(*C.idx_t)(&labels[0]),
 	); c != 0 {
-		err = getLastError()
+		return nil, nil, getLastError()
 	}
-
-	return
+	return distances, labels, nil
 }
 
 // -----------------------------------------------------------------------------

--- a/index.go
+++ b/index.go
@@ -398,7 +398,7 @@ func (idx *faissIndex) SearchWithOptions(x []float32, k int64, sel Selector, par
 	if sel == nil && params == nil {
 		return idx.Search(x, k)
 	}
-	return idx.searchWithParams(x, k, sel, params)
+	return idx.searchWithOptions(x, k, sel, params)
 }
 
 func (idx *faissIndex) Reconstruct(key int64) (recons []float32, err error) {
@@ -502,7 +502,7 @@ func (idx *faissIndex) Close() {
 	C.faiss_Index_free(idx.idx)
 }
 
-func (idx *faissIndex) searchWithParams(x []float32, k int64, sel Selector, params json.RawMessage) ([]float32, []int64, error) {
+func (idx *faissIndex) searchWithOptions(x []float32, k int64, sel Selector, params json.RawMessage) ([]float32, []int64, error) {
 	// Build a search params object to contain either the selector, the additional params, or both.
 	searchParams, err := NewSearchParams(idx, params, sel, nil)
 	if err != nil {

--- a/index_binary.go
+++ b/index_binary.go
@@ -189,10 +189,10 @@ func (b *faissBinaryIndex) SearchWithOptions(xb []uint8, k int64, sel Selector, 
 	if sel == nil && params == nil {
 		return b.Search(xb, k)
 	}
-	return b.searchWithParams(xb, k, sel, params)
+	return b.searchWithOptions(xb, k, sel, params)
 }
 
-func (b *faissBinaryIndex) searchWithParams(xb []uint8, k int64, selector Selector,
+func (b *faissBinaryIndex) searchWithOptions(xb []uint8, k int64, selector Selector,
 	params json.RawMessage) ([]int32, []int64, error) {
 	// Build a binary search params object to contain either the selector, the additional params, or both.
 	searchParams, err := NewBinarySearchParams(b, params, selector, nil)

--- a/index_binary.go
+++ b/index_binary.go
@@ -51,8 +51,10 @@ type BinaryIndex interface {
 	// their corresponding distances
 	Search(xb []uint8, k int64) (distances []int32, labels []int64, err error)
 
-	SearchWithSelector(xb []uint8, k int64, sel Selector,
-		params json.RawMessage) (distances []int32, labels []int64, err error)
+	// SearchWithOptions performs a search with additional optional constraints.
+	// - Selector can be used to restrict the search to a subset of the indexed vectors based on their IDs.
+	// - params is a JSON object that can contain additional search parameters specific to the index type, such as IVF search parameters.
+	SearchWithOptions(xb []uint8, k int64, sel Selector, params json.RawMessage) (distances []int32, labels []int64, err error)
 
 	// returns a slice where each index corresponds to a cluster in an IVF
 	// index, and the value at each index is the count of vectors in that
@@ -183,23 +185,16 @@ func (b *faissBinaryIndex) Search(xb []uint8, k int64) (
 	return distances, labels, nil
 }
 
-func (b *faissBinaryIndex) SearchWithSelector(xb []uint8, k int64, sel Selector,
-	params json.RawMessage) ([]int32, []int64, error) {
-	// If no selector is provided, we have no results to return.
-	// return an error indicating that the SearchWithSelector requires a valid selector.
-	if sel == nil {
-		return nil, nil, fmt.Errorf("SearchWithSelector requires a valid selector")
-	}
-	if params == nil {
+func (b *faissBinaryIndex) SearchWithOptions(xb []uint8, k int64, sel Selector, params json.RawMessage) ([]int32, []int64, error) {
+	if sel == nil && params == nil {
 		return b.Search(xb, k)
 	}
-
 	return b.searchWithParams(xb, k, sel, params)
 }
 
 func (b *faissBinaryIndex) searchWithParams(xb []uint8, k int64, selector Selector,
 	params json.RawMessage) ([]int32, []int64, error) {
-
+	// Build a binary search params object to contain either the selector, the additional params, or both.
 	searchParams, err := NewBinarySearchParams(b, params, selector, nil)
 	if err != nil {
 		return nil, nil, err

--- a/search_params.go
+++ b/search_params.go
@@ -143,7 +143,9 @@ func NewStandardSearchParams(selector Selector) (*SearchParams, error) {
 
 func NewBinarySearchParams(idx BinaryIndex, params json.RawMessage, selector Selector,
 	defaultParams *defaultSearchParamsIVF) (*SearchParams, error) {
-
+	// Get the selector C pointer, if any.
+	// A nil selector indicates no ID filtering, and it is valid
+	// to send a nil pointer to Faiss.
 	var sel *C.FaissIDSelector
 	if selector != nil {
 		sel = selector.Get()


### PR DESCRIPTION
- Fix `SearchWithSelector` API signatures for float32 and BIVF indices.
- Rename the API to `SearchWithOptions` which takes in optional constraints like:
   - Vector Selector
   - Search Parameters
- If none of the constraints are provided, we fall back to the regular search API.
- If either or both constraints are provided, we create a search params object and execute the FAISS API for parameterized search.