### PR TITLE
Refactor index methods to use `faissIndex` type for consistency

### DIFF
--- a/index.go
+++ b/index.go
@@ -439,13 +439,6 @@ func (idx *faissIndex) ReconstructBatch(keys []int64, recons []float32) ([]float
 	return recons, err
 }
 
-func (i *IndexImpl) MergeFrom(other Index, add_id int64) error {
-	if impl, ok := other.(*IndexImpl); ok {
-		return i.Index.MergeFrom(impl.Index, add_id)
-	}
-	return fmt.Errorf("merge not support")
-}
-
 func (idx *faissIndex) MergeFrom(other Index, add_id int64) (err error) {
 	otherIdx, ok := other.(*faissIndex)
 	if !ok {

--- a/index.go
+++ b/index.go
@@ -33,6 +33,15 @@ type Index interface {
 	// Ntotal returns the number of indexed vectors.
 	Ntotal() int64
 
+	// set the direct map type for IVF indexes.
+	// 0 for No Map
+	// 1 for Array
+	// 2 for Hash
+	SetDirectMap(maptype int) error
+
+	// set the number of probes for IVF indexes
+	SetNProbe(nprobe int32)
+
 	// MetricType returns the metric type of the index.
 	MetricType() int
 
@@ -48,8 +57,14 @@ type Index interface {
 	// Returns true if the index is an IVF index.
 	IsIVFIndex() bool
 
+	// Returns true if the index is a scalar quantization (SQ) index.
+	IsSQIndex() bool
+
 	// Returns true if the index has RaBitQ
 	HasRaBitQ() bool
+
+	// Returns the IVF parameters nprobe and nlist for IVF indexes.
+	IVFParams() (nprobe, nlist int)
 
 	// Applicable only to IVF indexes: Returns a slice where each index represents
 	// a cluster (list) ID and the value is the count of selected vectors belonging

--- a/index_flat.go
+++ b/index_flat.go
@@ -44,13 +44,3 @@ func (idx *IndexFlat) Xb() []float32 {
 	C.faiss_IndexFlat_xb(idx.cPtr(), &ptr, &size)
 	return (*[1 << 30]float32)(unsafe.Pointer(ptr))[:size:size]
 }
-
-// AsFlat casts idx to a flat index.
-// AsFlat panics if idx is not a flat index.
-func (idx *IndexImpl) AsFlat() *IndexFlat {
-	ptr := C.faiss_IndexFlat_cast(idx.cPtr())
-	if ptr == nil {
-		panic("index is not a flat index")
-	}
-	return &IndexFlat{&faissIndex{ptr}}
-}

--- a/index_ivf.go
+++ b/index_ivf.go
@@ -13,7 +13,7 @@ import (
 	"fmt"
 )
 
-func (idx *IndexImpl) SetDirectMap(mapType int) (err error) {
+func (idx *faissIndex) SetDirectMap(mapType int) (err error) {
 
 	ivfPtr := C.faiss_IndexIVF_cast(idx.cPtr())
 	if ivfPtr == nil {
@@ -28,7 +28,7 @@ func (idx *IndexImpl) SetDirectMap(mapType int) (err error) {
 	return err
 }
 
-func (idx *IndexImpl) GetSubIndex() (*IndexImpl, error) {
+func (idx *faissIndex) GetSubIndex() (Index, error) {
 
 	ptr := C.faiss_IndexIDMap2_cast(idx.cPtr())
 	if ptr == nil {
@@ -45,7 +45,7 @@ func (idx *IndexImpl) GetSubIndex() (*IndexImpl, error) {
 
 // pass nprobe to be set as index time option for IVF indexes only.
 // varying nprobe impacts recall but with an increase in latency.
-func (idx *IndexImpl) SetNProbe(nprobe int32) {
+func (idx *faissIndex) SetNProbe(nprobe int32) {
 	ivfPtr := C.faiss_IndexIVF_cast(idx.cPtr())
 	if ivfPtr == nil {
 		return
@@ -53,7 +53,7 @@ func (idx *IndexImpl) SetNProbe(nprobe int32) {
 	C.faiss_IndexIVF_set_nprobe(ivfPtr, C.size_t(nprobe))
 }
 
-func (idx *IndexImpl) IVFParams() (nprobe, nlist int) {
+func (idx *faissIndex) IVFParams() (nprobe, nlist int) {
 	ivfPtr := C.faiss_IndexIVF_cast(idx.cPtr())
 	if ivfPtr == nil {
 		return 0, 0
@@ -62,13 +62,13 @@ func (idx *IndexImpl) IVFParams() (nprobe, nlist int) {
 		int(C.faiss_IndexIVF_nlist(ivfPtr))
 }
 
-func (idx *IndexImpl) IsSQIndex() bool {
+func (idx *faissIndex) IsSQIndex() bool {
 	sqPtr := C.faiss_IndexScalarQuantizer_cast(idx.cPtr())
 	return sqPtr != nil
 }
 
 func (idx *faissIndex) SetQuantizers(srcIndex Index) error {
-	ivfPtr := C.faiss_IndexIVF_cast(idx.idx)
+	ivfPtr := C.faiss_IndexIVF_cast(idx.cPtr())
 	if ivfPtr == nil {
 		return fmt.Errorf("index is not of ivf type")
 	}
@@ -84,8 +84,4 @@ func (idx *faissIndex) SetQuantizers(srcIndex Index) error {
 	}
 
 	return nil
-}
-
-func (idx *IndexImpl) SetQuantizers(srcIndex Index) error {
-	return idx.Index.SetQuantizers(srcIndex)
 }


### PR DESCRIPTION
- Currently we have one implementation of the `Index` interface which is the `faissIndex`
  struct. We also have another struct called `IndexImpl` which is a wrapper around 
  the `faissIndex` struct.
- However we have pointer receivers to either `IndexImpl` or `faissIndex`, leading to 
  inconsistencies and duplicated APIs.
- This PR cleans up the APIs to only have pointer receivers to the `faissIndex` struct, 
  similar to how we do it for the `binaryFaissIndex` struct. 