### PR TITLE
Enhance stability of GPU cloning

### DIFF
--- a/gpu.go
+++ b/gpu.go
@@ -53,8 +53,8 @@ const (
 )
 
 const (
-	// the default amount of memory to be reserved per
-	defaultGPUBufferSize = 512 * 1024 * 1024 // 512 MiB
+	// the minimum amount of free memory that must be available on a GPU to be considered for index cloning.
+	minGPUFreeMemory = 512 * 1024 * 1024 // 512 MiB
 	// the default memory space to use for GPU indices
 	defaultGPUMemoryMode = memorySpaceUnified
 )
@@ -148,16 +148,16 @@ func (lb *gpuLoadBalancer) refresh() {
 	}
 	wg.Wait()
 
-	// Only include devices that reported non-zero free memory.
+	// Only include devices that reported non-zero free memory, and have at least minGPUFreeMemory free.
 	for i, mem := range lb.freeMemory {
-		if mem > 0 {
+		if mem > minGPUFreeMemory {
 			lb.scratchDevs = append(lb.scratchDevs, i)
 		}
 	}
 
 	// Shuffle first, then sort descending by free memory to make the
 	// sort as "unstable" as possible
-	// This is useful to add fairness between GPUs with the same memory 
+	// This is useful to add fairness between GPUs with the same memory
 	rand.Shuffle(len(lb.scratchDevs), func(i, j int) {
 		lb.scratchDevs[i], lb.scratchDevs[j] = lb.scratchDevs[j], lb.scratchDevs[i]
 	})
@@ -252,10 +252,12 @@ func CloneToGPU(cpuIndex *IndexImpl) (*GPUIndexImpl, error) {
 		return nil, fmt.Errorf("failed to initialize GPU resources: error code %d, err: %v", code, getLastError())
 	}
 
-	// override the max buffer size to be used for the clone operation;
-	if code := C.faiss_StandardGpuResources_setTempMemory(gpuResource, C.size_t(defaultGPUBufferSize)); code != 0 {
+	// Disable the pre-allocated temp memory pool so that all GPU memory is
+	// available for index data; unified memory mode handles intermediate
+	// allocations via cudaMalloc/cudaFree on demand.
+	if code := C.faiss_StandardGpuResources_noTempMemory(gpuResource); code != 0 {
 		C.faiss_StandardGpuResources_free(gpuResource)
-		return nil, fmt.Errorf("failed to set GPU temp memory: error code %d, err: %v", code, getLastError())
+		return nil, fmt.Errorf("failed to disable GPU temp memory: error code %d, err: %v", code, getLastError())
 	}
 
 	var clonerOpts *C.FaissGpuClonerOptions


### PR DESCRIPTION
- Our current algorithm for index cloning:
    - Any GPU device with free memory > 0 bytes is considered eligible for index cloning.
    - During `CloneToGPU`, a 512 MiB temp memory pool is pre-allocated per index 
      for intermediate GPU computations (scratch space for search, quantization, etc.). 
      This reservation reduces the memory available for actual index data from other 
      clone operations.
- This PR proposes a new algorithm for index cloning:
    - Only GPU devices with free memory > 512 MiB (`minGPUFreeMemory`) are 
      considered eligible. This prevents the load balancer from selecting 
      nearly-full GPUs that would likely 
      fail the clone operation anyway. 
    - We can also prevent OOM errors from occurring within FAISS by establishing 
      this condition in the application layer itself, for more controlled error handling.
    - The pre-allocated temp memory pool is disabled entirely, since we guarantee 
      at least 512MB of free memory in the GPU which acts as a ad-hoc buffer for 
      any intermediate allocs done by any of the cloned GPU indices. 