### PR TITLE
MB-71397: Add a maximal-effort strategy to avoid OOM errors for GPU indexes.

### DIFF
--- a/gpu.go
+++ b/gpu.go
@@ -23,6 +23,8 @@ package faiss
 #include <faiss/c_api/gpu/GpuAutoTune_c.h>
 #include <faiss/c_api/gpu/GpuClonerOptions_c.h>
 #include <faiss/c_api/gpu/DeviceUtils_c.h>
+#include <faiss/c_api/gpu/GpuIndex_c.h>
+#include <faiss/c_api/gpu/GpuIndexIVF_c.h>
 */
 import "C"
 import (
@@ -34,7 +36,6 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
-	"unsafe"
 )
 
 var (
@@ -42,6 +43,10 @@ var (
 	errNilIndex            = errors.New("index is nil")
 	errNoGPUDevices        = errors.New("no GPU devices available")
 	errNotEnoughGPUMemory  = errors.New("selected GPU device does not have enough free memory for cloning")
+	errTrainFailed         = errors.New("training failed on GPU index")
+	errAddFailed           = errors.New("adding vectors failed on GPU index")
+	errMemoryReserveFailed = errors.New("failed to reserve memory on GPU index")
+	errSearchFailed        = errors.New("search failed on GPU index")
 )
 
 // memorySpace controls where GPU index data is allocated.
@@ -65,15 +70,16 @@ const (
 )
 
 var (
-	gpuCount                      int
-	loadBalancer                  *gpuLoadBalancer
-	reflectStaticSizeGPUIndexImpl uint64
-	serializer                    *gpuIndexSerializer
+	gpuCount     int
+	loadBalancer *gpuLoadBalancer
+	serializer   *gpuIndexSerializer
 )
 
+var reflectStaticSizefaissGPUIndex uint64
+
 func init() {
-	var f GPUIndexImpl
-	reflectStaticSizeGPUIndexImpl = uint64(reflect.TypeOf(f).Size())
+	var g faissGPUIndex
+	reflectStaticSizefaissGPUIndex = uint64(reflect.TypeOf(g).Size())
 
 	var err error
 	gpuCount, err = numGPUs()
@@ -111,6 +117,11 @@ func getFreeGPUMemory(device int) uint64 {
 		return uint64(freeBytes)
 	}
 	return 0
+}
+
+// hasEnoughGPUMemory returns true if the GPU has enough free memory for the required allocation plus a buffer.
+func hasEnoughGPUMemory(freeMem, requiredMemory uint64) bool {
+	return freeMem > requiredMemory+defaultGPUMinFreeMemory
 }
 
 // --------------------------------------------------------------------------------
@@ -246,30 +257,104 @@ func (s *gpuIndexSerializer) release(device int) {
 
 // --------------------------------------------------------------------------------
 
-type GPUIndexImpl struct {
-	idx         *faissIndex
+type GPUIndex interface {
+	// D returns the dimension of the indexed vectors.
+	D() int
+	// Add adds vectors to the index.
+	// Resurns two errors:
+	//  - The first error indicates failure to reserve memory for the add operation.
+	//  - The second error indicates failure to add the vectors after successful memory reservation.
+	Add(x []float32) (error, error)
+	// Train trains the index on a representative set of vectors.
+	Train(x []float32) error
+	// Search queries the index with the vectors in x.
+	// Returns the IDs of the k nearest neighbors for each query vector and the
+	// corresponding distances.
+	Search(x []float32, k int64) (distances []float32, labels []int64, err error)
+	// Size estimates the memory footprint of the index assuming in bytes,
+	// if the underlying faiss index is memory-mapped and not fully loaded into memory.
+	Size() uint64
+	// Close frees the memory used by the index.
+	Close()
+	// gPtr returns the underlying C pointer to the FaissGpuIndex.
+	gPtr() *C.FaissGpuIndex
+}
+
+type faissGPUIndex struct {
+	idx         *C.FaissGpuIndex
 	gpuResource *C.FaissStandardGpuResources
+	device      int
+	codeSize    uint64
 }
 
-func (g *GPUIndexImpl) cPtr() *C.FaissIndex {
-	return g.idx.idx
+func (g *faissGPUIndex) gPtr() *C.FaissGpuIndex {
+	return g.idx
 }
 
-func (g *GPUIndexImpl) Train(x []float32) error {
-	return g.idx.Train(x)
+func (g *faissGPUIndex) D() int {
+	return int(C.faiss_GpuIndex_d(g.idx))
 }
 
-func (g *GPUIndexImpl) Add(x []float32) error {
-	return g.idx.Add(x)
+func (g *faissGPUIndex) Add(x []float32) (error, error) {
+	n := len(x) / g.D()
+	// cast to gpu ivf index first
+	var ivfIdx *C.FaissGpuIndexIVF
+	ivfIdx = C.faiss_GpuIndexIVF_cast(g.idx)
+	if ivfIdx != nil {
+		// try to reserve memory for the new vectors first if possible
+		// acquire device lock for memory allocation
+		serializer.acquire(g.device)
+		// early exit path. Use a heuristic to determine the minimum
+		// memory needed to add the vectors before attempting to reserve memory or add to the index,
+		// to avoid unnecessary work and errors when adding a large batch of vectors that exceed GPU memory.
+		requiredMemory := uint64(n) * g.codeSize
+		freeMem := getFreeGPUMemory(g.device)
+		if !hasEnoughGPUMemory(freeMem, requiredMemory) {
+			serializer.release(g.device)
+			return errNotEnoughGPUMemory, nil
+		}
+		// actually reserve the memory on the GPU for the new vectors.
+		if c := C.faiss_GpuIndexIVF_reserve_memory(ivfIdx, C.size_t(n)); c != 0 {
+			serializer.release(g.device)
+			return errMemoryReserveFailed, nil
+		}
+		serializer.release(g.device)
+	}
+	if c := C.faiss_GpuIndex_add(g.idx, C.idx_t(n), (*C.float)(&x[0])); c != 0 {
+		return nil, errAddFailed
+	}
+	return nil, nil
 }
 
-func (g *GPUIndexImpl) Search(x []float32, k int64) ([]float32, []int64, error) {
-	return g.idx.Search(x, k)
+func (g *faissGPUIndex) Train(x []float32) error {
+	n := len(x) / g.D()
+	if c := C.faiss_GpuIndex_train(g.idx, C.idx_t(n), (*C.float)(&x[0])); c != 0 {
+		return errTrainFailed
+	}
+	return nil
 }
 
-func (g *GPUIndexImpl) Close() {
+func (g *faissGPUIndex) Search(x []float32, k int64) ([]float32, []int64, error) {
+	n := len(x) / g.D()
+	distances := make([]float32, int64(n)*k)
+	labels := make([]int64, int64(n)*k)
+	if c := C.faiss_GpuIndex_search(
+		g.idx,
+		C.idx_t(n),
+		(*C.float)(&x[0]),
+		C.idx_t(k),
+		(*C.float)(&distances[0]),
+		(*C.idx_t)(&labels[0]),
+	); c != 0 {
+		return nil, nil, errSearchFailed
+	}
+
+	return distances, labels, nil
+}
+
+func (g *faissGPUIndex) Close() {
 	if g.idx != nil {
-		g.idx.Close()
+		C.faiss_GpuIndex_free(g.idx)
 		g.idx = nil
 	}
 	if g.gpuResource != nil {
@@ -278,8 +363,12 @@ func (g *GPUIndexImpl) Close() {
 	}
 }
 
-func (g *GPUIndexImpl) Size() uint64 {
-	return reflectStaticSizeGPUIndexImpl + g.idx.Size()
+func (g *faissGPUIndex) Size() uint64 {
+	return reflectStaticSizefaissGPUIndex
+}
+
+type GPUIndexImpl struct {
+	GPUIndex
 }
 
 // CloneToGPU transfers a CPU index to the best available GPU based on free memory.
@@ -296,26 +385,21 @@ func CloneToGPU(cpuIndex *IndexImpl) (*GPUIndexImpl, error) {
 	// Acquire the GPU resource for the duration of the clone operation to prevent oversubscription.
 	serializer.acquire(device)
 	defer serializer.release(device)
-
-	// first check if we have enough free memory on the selected GPU before attempting the clone, to avoid unnecessary work and errors.
-	freeMem := getFreeGPUMemory(device)
 	// amount of GPU memory required for the index clone
 	requiredMemory, err := cpuIndex.IndexSize()
 	if err != nil {
 		return nil, err
 	}
-
+	// first check if we have enough free memory on the selected GPU before attempting the clone, to avoid unnecessary work and errors.
+	freeMem := getFreeGPUMemory(device)
 	// The GPU must have enough free memory for the index plus a minimum buffer.
-	// Compare as freeMem < required + buffer to avoid uint64 underflow from subtraction.
-	if freeMem < requiredMemory+defaultGPUMinFreeMemory {
+	if !hasEnoughGPUMemory(freeMem, requiredMemory) {
 		return nil, errNotEnoughGPUMemory
 	}
-
 	var gpuResource *C.FaissStandardGpuResources
 	if code := C.faiss_StandardGpuResources_new(&gpuResource); code != 0 {
 		return nil, fmt.Errorf("failed to initialize GPU resources: error code %d, err: %v", code, getLastError())
 	}
-
 	// Disable the pre-allocated temp memory pool so that all GPU memory is
 	// available for index data; unified memory mode handles intermediate
 	// allocations via cudaMalloc/cudaFree on demand.
@@ -327,16 +411,13 @@ func CloneToGPU(cpuIndex *IndexImpl) (*GPUIndexImpl, error) {
 		C.faiss_StandardGpuResources_free(gpuResource)
 		return nil, fmt.Errorf("failed to disable GPU pinned memory: error code %d, err: %v", code, getLastError())
 	}
-
 	var clonerOpts *C.FaissGpuClonerOptions
 	if code := C.faiss_GpuClonerOptions_new(&clonerOpts); code != 0 {
 		C.faiss_StandardGpuResources_free(gpuResource)
 		return nil, fmt.Errorf("failed to create cloner options: error code %d, err: %v", code, getLastError())
 	}
 	defer C.faiss_GpuClonerOptions_free(clonerOpts)
-
 	C.faiss_GpuClonerOptions_set_memorySpace(clonerOpts, C.int(defaultGPUMemoryMode))
-
 	var gpuIdx *C.FaissGpuIndex
 	code := C.faiss_index_cpu_to_gpu_with_options(
 		gpuResource,
@@ -349,25 +430,27 @@ func CloneToGPU(cpuIndex *IndexImpl) (*GPUIndexImpl, error) {
 		C.faiss_StandardGpuResources_free(gpuResource)
 		return nil, fmt.Errorf("failed to transfer index to GPU device %d: error code %d, err: %v", device, code, getLastError())
 	}
-
-	idx := &faissIndex{
-		idx: (*C.FaissIndex)(unsafe.Pointer(gpuIdx)),
+	codeSize, err := cpuIndex.CodeSize()
+	if err != nil {
+		C.faiss_StandardGpuResources_free(gpuResource)
+		return nil, err
 	}
-
-	return &GPUIndexImpl{
-		idx:         idx,
+	g := &faissGPUIndex{
+		idx:         gpuIdx,
 		gpuResource: gpuResource,
-	}, nil
+		device:      device,
+		codeSize:    codeSize,
+	}
+	return &GPUIndexImpl{g}, nil
 }
 
 func CloneToCPU(gpuIndex *GPUIndexImpl) (*IndexImpl, error) {
 	if gpuIndex == nil {
 		return nil, errNilIndex
 	}
-
 	var cpuIdx *C.FaissIndex
 	code := C.faiss_index_gpu_to_cpu(
-		gpuIndex.cPtr(),
+		gpuIndex.gPtr(),
 		&cpuIdx,
 	)
 	if code != 0 {

--- a/gpu.go
+++ b/gpu.go
@@ -68,7 +68,7 @@ var (
 	gpuCount                      int
 	loadBalancer                  *gpuLoadBalancer
 	reflectStaticSizeGPUIndexImpl uint64
-	scheduler                     *gpuScheduler
+	serializer                    *gpuIndexSerializer
 )
 
 func init() {
@@ -86,10 +86,10 @@ func init() {
 		loadBalancer = newGPULoadBalancer(500 * time.Millisecond)
 		go loadBalancer.monitor()
 	}
-	// Initialize the GPU scheduler if at least one GPU is available;
+	// Initialize the GPU serializer if at least one GPU is available;
 	// it will be used to serialize access to each GPU device to prevent oversubscription.
 	if gpuCount > 0 {
-		scheduler = newGPUScheduler(gpuCount)
+		serializer = newGPUIndexSerializer(gpuCount)
 	}
 }
 
@@ -211,7 +211,7 @@ func (lb *gpuLoadBalancer) nextDevice() (int, error) {
 }
 
 func getBestGPUDevice() (int, error) {
-	if gpuCount == 0 || scheduler == nil {
+	if gpuCount == 0 || serializer == nil {
 		return 0, errNoGPUDevices
 	}
 	// If loadBalancer is nil, it means we have only 1 GPU, so just return device 0.
@@ -222,25 +222,25 @@ func getBestGPUDevice() (int, error) {
 }
 
 // --------------------------------------------------------------------------------
-// gpuScheduler provides a simple mutex-like mechanism to serialize index clones to
+// gpuIndexSerializer provides a simple mutex-like mechanism to serialize index clones to
 // each GPU device, preventing oversubscription and out-of-memory errors when multiple
 // goroutines attempt to clone to the same GPU at the same time.
-type gpuScheduler struct {
+type gpuIndexSerializer struct {
 	deviceMu []sync.Mutex
 }
 
-func newGPUScheduler(numGPUs int) *gpuScheduler {
-	s := &gpuScheduler{
+func newGPUIndexSerializer(numGPUs int) *gpuIndexSerializer {
+	s := &gpuIndexSerializer{
 		deviceMu: make([]sync.Mutex, numGPUs),
 	}
 	return s
 }
 
-func (s *gpuScheduler) acquire(device int) {
+func (s *gpuIndexSerializer) acquire(device int) {
 	s.deviceMu[device].Lock()
 }
 
-func (s *gpuScheduler) release(device int) {
+func (s *gpuIndexSerializer) release(device int) {
 	s.deviceMu[device].Unlock()
 }
 
@@ -294,13 +294,16 @@ func CloneToGPU(cpuIndex *IndexImpl) (*GPUIndexImpl, error) {
 		return nil, err
 	}
 	// Acquire the GPU resource for the duration of the clone operation to prevent oversubscription.
-	scheduler.acquire(device)
-	defer scheduler.release(device)
+	serializer.acquire(device)
+	defer serializer.release(device)
 
 	// first check if we have enough free memory on the selected GPU before attempting the clone, to avoid unnecessary work and errors.
 	freeMem := getFreeGPUMemory(device)
 	// amount of GPU memory required for the index clone
-	requiredMemory := cpuIndex.Size()
+	requiredMemory, err := cpuIndex.IndexSize()
+	if err != nil {
+		return nil, err
+	}
 
 	// The GPU must have enough free memory for the index plus a minimum buffer.
 	// Compare as freeMem < required + buffer to avoid uint64 underflow from subtraction.

--- a/gpu.go
+++ b/gpu.go
@@ -299,7 +299,12 @@ func CloneToGPU(cpuIndex *IndexImpl) (*GPUIndexImpl, error) {
 
 	// first check if we have enough free memory on the selected GPU before attempting the clone, to avoid unnecessary work and errors.
 	freeMem := getFreeGPUMemory(device)
-	if freeMem < minGPUFreeMemory {
+	// amount of GPU memory required for the index clone
+	requiredMemory := cpuIndex.Size()
+
+	// The GPU must have enough free memory for the index plus a minimum buffer.
+	// Compare as freeMem < required + buffer to avoid uint64 underflow from subtraction.
+	if freeMem < requiredMemory+minGPUFreeMemory {
 		return nil, errNotEnoughGPUMemory
 	}
 
@@ -341,6 +346,27 @@ func CloneToGPU(cpuIndex *IndexImpl) (*GPUIndexImpl, error) {
 		C.faiss_StandardGpuResources_free(gpuResource)
 		return nil, fmt.Errorf("failed to transfer index to GPU device %d: error code %d, err: %v", device, code, getLastError())
 	}
+
+	// With cudaMallocManaged (unified memory) pages are lazily migrated;
+	// synchronize the device first to force all pages to be reported as resident
+	// before querying free memory, otherwise the reading is unreliable.
+	C.faiss_gpu_sync_all_devices()
+	freeMemPost := getFreeGPUMemory(device)
+	actualUsed := freeMem - freeMemPost
+	diff := int64(actualUsed) - int64(requiredMemory)
+	diffSign := "+"
+	if diff < 0 {
+		diffSign = "-"
+		diff = -diff
+	}
+	fmt.Printf("clone gpu=%-2d  pre=%6.0f MB  est=%6.0f MB  post=%6.0f MB  actual=%6.0f MB  diff=%s%.0f MB\n",
+		device,
+		float64(freeMem)/1024/1024,
+		float64(requiredMemory)/1024/1024,
+		float64(freeMemPost)/1024/1024,
+		float64(actualUsed)/1024/1024,
+		diffSign, float64(diff)/1024/1024,
+	)
 
 	idx := &faissIndex{
 		idx: (*C.FaissIndex)(unsafe.Pointer(gpuIdx)),

--- a/gpu.go
+++ b/gpu.go
@@ -29,6 +29,7 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
+	"reflect"
 	"sort"
 	"sync"
 	"sync/atomic"
@@ -63,11 +64,15 @@ const (
 )
 
 var (
-	gpuCount     int
-	loadBalancer *gpuLoadBalancer
+	gpuCount                      int
+	loadBalancer                  *gpuLoadBalancer
+	reflectStaticSizeGPUIndexImpl uint64
 )
 
 func init() {
+	var f GPUIndexImpl
+	reflectStaticSizeGPUIndexImpl = uint64(reflect.TypeOf(f).Size())
+
 	var err error
 	gpuCount, err = numGPUs()
 	if err != nil || gpuCount <= 0 {
@@ -195,7 +200,6 @@ func getBestGPUDevice() (int, error) {
 	return loadBalancer.nextDevice()
 }
 
-// only expose API used by zapx
 type GPUIndexImpl struct {
 	idx         *faissIndex
 	gpuResource *C.FaissStandardGpuResources
@@ -226,6 +230,10 @@ func (g *GPUIndexImpl) Close() {
 		C.faiss_StandardGpuResources_free(g.gpuResource)
 		g.gpuResource = nil
 	}
+}
+
+func (g *GPUIndexImpl) Size() uint64 {
+	return reflectStaticSizeGPUIndexImpl + g.idx.Size()
 }
 
 // CloneToGPU transfers a CPU index to the best available GPU based on free memory.

--- a/gpu.go
+++ b/gpu.go
@@ -56,8 +56,8 @@ const (
 )
 
 const (
-	// the minimum amount of free memory that must be available on a GPU to be considered for index cloning.
-	minGPUFreeMemory = 512 * 1024 * 1024 // 512 MiB
+	// the default minimum amount of free memory that must be available on a GPU to be considered for index cloning.
+	defaultGPUMinFreeMemory = 512 * 1024 * 1024 // 512 MiB
 	// the default memory space to use for GPU indices.
 	defaultGPUMemoryMode = memorySpaceUnified
 	// the default amount of pinned memory to allocate for each GPU clone operation.
@@ -169,7 +169,7 @@ func (lb *gpuLoadBalancer) refresh() {
 	// Only include devices that reported non-zero free memory and
 	// have at least the minimum required free memory for cloning.
 	for i, mem := range lb.freeMemory {
-		if mem > 0 && mem >= minGPUFreeMemory {
+		if mem > 0 && mem >= defaultGPUMinFreeMemory {
 			lb.scratchDevs = append(lb.scratchDevs, i)
 		}
 	}
@@ -304,7 +304,7 @@ func CloneToGPU(cpuIndex *IndexImpl) (*GPUIndexImpl, error) {
 
 	// The GPU must have enough free memory for the index plus a minimum buffer.
 	// Compare as freeMem < required + buffer to avoid uint64 underflow from subtraction.
-	if freeMem < requiredMemory+minGPUFreeMemory {
+	if freeMem < requiredMemory+defaultGPUMinFreeMemory {
 		return nil, errNotEnoughGPUMemory
 	}
 
@@ -346,27 +346,6 @@ func CloneToGPU(cpuIndex *IndexImpl) (*GPUIndexImpl, error) {
 		C.faiss_StandardGpuResources_free(gpuResource)
 		return nil, fmt.Errorf("failed to transfer index to GPU device %d: error code %d, err: %v", device, code, getLastError())
 	}
-
-	// With cudaMallocManaged (unified memory) pages are lazily migrated;
-	// synchronize the device first to force all pages to be reported as resident
-	// before querying free memory, otherwise the reading is unreliable.
-	C.faiss_gpu_sync_all_devices()
-	freeMemPost := getFreeGPUMemory(device)
-	actualUsed := freeMem - freeMemPost
-	diff := int64(actualUsed) - int64(requiredMemory)
-	diffSign := "+"
-	if diff < 0 {
-		diffSign = "-"
-		diff = -diff
-	}
-	fmt.Printf("clone gpu=%-2d  pre=%6.0f MB  est=%6.0f MB  post=%6.0f MB  actual=%6.0f MB  diff=%s%.0f MB\n",
-		device,
-		float64(freeMem)/1024/1024,
-		float64(requiredMemory)/1024/1024,
-		float64(freeMemPost)/1024/1024,
-		float64(actualUsed)/1024/1024,
-		diffSign, float64(diff)/1024/1024,
-	)
 
 	idx := &faissIndex{
 		idx: (*C.FaissIndex)(unsafe.Pointer(gpuIdx)),

--- a/gpu.go
+++ b/gpu.go
@@ -41,6 +41,7 @@ var (
 	errAccessingGPUDevices = errors.New("error accessing GPU devices")
 	errNilIndex            = errors.New("index is nil")
 	errNoGPUDevices        = errors.New("no GPU devices available")
+	errNotEnoughGPUMemory  = errors.New("selected GPU device does not have enough free memory for cloning")
 )
 
 // memorySpace controls where GPU index data is allocated.
@@ -67,6 +68,7 @@ var (
 	gpuCount                      int
 	loadBalancer                  *gpuLoadBalancer
 	reflectStaticSizeGPUIndexImpl uint64
+	scheduler                     *gpuScheduler
 )
 
 func init() {
@@ -78,10 +80,16 @@ func init() {
 	if err != nil || gpuCount <= 0 {
 		gpuCount = 0
 	}
-	if gpuCount > 0 {
-		// TODO: verify if 500 milliseconds is a good interval
+	// Only initialize the load balancer if multiple GPUs are available,
+	// as it's not needed for a single GPU and adds overhead from monitoring.
+	if gpuCount > 1 {
 		loadBalancer = newGPULoadBalancer(500 * time.Millisecond)
 		go loadBalancer.monitor()
+	}
+	// Initialize the GPU scheduler if at least one GPU is available;
+	// it will be used to serialize access to each GPU device to prevent oversubscription.
+	if gpuCount > 0 {
+		scheduler = newGPUScheduler(gpuCount)
 	}
 }
 
@@ -95,6 +103,17 @@ func numGPUs() (int, error) {
 	return int(rv), nil
 }
 
+// getFreeGPUMemory returns the amount of free memory in bytes for the specified GPU device.
+// It handles any CGO error by returning 0, which will allow callers to naturally exclude that device from selection.
+func getFreeGPUMemory(device int) uint64 {
+	var freeBytes C.size_t
+	if c := C.faiss_gpu_free_memory(C.int(device), &freeBytes); c == 0 {
+		return uint64(freeBytes)
+	}
+	return 0
+}
+
+// --------------------------------------------------------------------------------
 // gpuLoadBalancer monitors GPU free memory on a fixed interval, keeps a
 // memory-sorted list of devices, and hands them out in round-robin order.
 // At each interval the list is re-sorted and the round-robin counter resets
@@ -142,17 +161,15 @@ func (lb *gpuLoadBalancer) refresh() {
 	for i := 0; i < gpuCount; i++ {
 		go func(device int) {
 			defer wg.Done()
-			var freeBytes C.size_t
-			if C.faiss_gpu_free_memory(C.int(device), &freeBytes) == 0 {
-				lb.freeMemory[device] = uint64(freeBytes)
-			}
+			lb.freeMemory[device] = getFreeGPUMemory(device)
 		}(i)
 	}
 	wg.Wait()
 
-	// Only include devices that reported non-zero free memory, and have at least minGPUFreeMemory free.
+	// Only include devices that reported non-zero free memory and
+	// have at least the minimum required free memory for cloning.
 	for i, mem := range lb.freeMemory {
-		if mem > minGPUFreeMemory {
+		if mem > 0 && mem >= minGPUFreeMemory {
 			lb.scratchDevs = append(lb.scratchDevs, i)
 		}
 	}
@@ -194,11 +211,40 @@ func (lb *gpuLoadBalancer) nextDevice() (int, error) {
 }
 
 func getBestGPUDevice() (int, error) {
-	if gpuCount == 0 || loadBalancer == nil {
+	if gpuCount == 0 || scheduler == nil {
 		return 0, errNoGPUDevices
+	}
+	// If loadBalancer is nil, it means we have only 1 GPU, so just return device 0.
+	if loadBalancer == nil {
+		return 0, nil
 	}
 	return loadBalancer.nextDevice()
 }
+
+// --------------------------------------------------------------------------------
+// gpuScheduler provides a simple mutex-like mechanism to serialize index clones to
+// each GPU device, preventing oversubscription and out-of-memory errors when multiple
+// goroutines attempt to clone to the same GPU at the same time.
+type gpuScheduler struct {
+	deviceMu []sync.Mutex
+}
+
+func newGPUScheduler(numGPUs int) *gpuScheduler {
+	s := &gpuScheduler{
+		deviceMu: make([]sync.Mutex, numGPUs),
+	}
+	return s
+}
+
+func (s *gpuScheduler) acquire(device int) {
+	s.deviceMu[device].Lock()
+}
+
+func (s *gpuScheduler) release(device int) {
+	s.deviceMu[device].Unlock()
+}
+
+// --------------------------------------------------------------------------------
 
 type GPUIndexImpl struct {
 	idx         *faissIndex
@@ -246,6 +292,15 @@ func CloneToGPU(cpuIndex *IndexImpl) (*GPUIndexImpl, error) {
 	device, err := getBestGPUDevice()
 	if err != nil {
 		return nil, err
+	}
+	// Acquire the GPU resource for the duration of the clone operation to prevent oversubscription.
+	scheduler.acquire(device)
+	defer scheduler.release(device)
+
+	// first check if we have enough free memory on the selected GPU before attempting the clone, to avoid unnecessary work and errors.
+	freeMem := getFreeGPUMemory(device)
+	if freeMem < minGPUFreeMemory {
+		return nil, errNotEnoughGPUMemory
 	}
 
 	var gpuResource *C.FaissStandardGpuResources

--- a/gpu_stub.go
+++ b/gpu_stub.go
@@ -22,8 +22,8 @@ import "errors"
 // GPUIndexImpl is an opaque type when not built with GPU support.
 type GPUIndexImpl struct{}
 
-func (g *GPUIndexImpl) Train(x []float32) error { return errGPUNotBuilt }
-func (g *GPUIndexImpl) Add(x []float32) error   { return errGPUNotBuilt }
+func (g *GPUIndexImpl) Train(x []float32) error        { return errGPUNotBuilt }
+func (g *GPUIndexImpl) Add(x []float32) (error, error) { return nil, errGPUNotBuilt }
 func (g *GPUIndexImpl) Search(x []float32, k int64) ([]float32, []int64, error) {
 	return nil, nil, errGPUNotBuilt
 }

--- a/gpu_stub.go
+++ b/gpu_stub.go
@@ -27,7 +27,8 @@ func (g *GPUIndexImpl) Add(x []float32) error   { return errGPUNotBuilt }
 func (g *GPUIndexImpl) Search(x []float32, k int64) ([]float32, []int64, error) {
 	return nil, nil, errGPUNotBuilt
 }
-func (g *GPUIndexImpl) Close() {}
+func (g *GPUIndexImpl) Close()       {}
+func (g *GPUIndexImpl) Size() uint64 { return 0 }
 
 var errGPUNotBuilt = errors.New("not built with GPU support (requires -tags gpu)")
 

--- a/index.go
+++ b/index.go
@@ -139,7 +139,10 @@ func (idx *faissIndex) cPtr() *C.FaissIndex {
 }
 
 func (idx *faissIndex) Size() uint64 {
-	size := C.faiss_Index_size(idx.idx)
+	var size C.size_t
+	if code := C.faiss_Index_size(idx.idx, &size); code != 0 {
+		return 0
+	}
 	return uint64(size)
 }
 

--- a/index.go
+++ b/index.go
@@ -128,12 +128,13 @@ type Index interface {
 	// Close frees the memory used by the index.
 	Close()
 
-	// Size returns the Go struct size, excluding the C index memory.
-	// Suitable for memory-mapped indexes where the C memory is not RAM-resident.
+	// Size estimates the memory footprint of the index assuming in bytes,
+	// if the underlying faiss index is memory-mapped and not fully loaded into memory.
 	Size() uint64
 
-	// IndexSize returns the RAM footprint of the C index as reported by FAISS.
-	// Use this when the index is fully loaded in memory (e.g. after a GPU clone).
+	// IndexSize estimates the RAM footprint of the index in bytes,
+	// if the index is um-mapped and fully loaded into memory.
+	// This is a best effort estimation and may not be exact.
 	IndexSize() (uint64, error)
 
 	// cPtr returns a pointer to the underlying C index struct.

--- a/index.go
+++ b/index.go
@@ -137,6 +137,9 @@ type Index interface {
 	// This is a best effort estimation and may not be exact.
 	IndexSize() (uint64, error)
 
+	// CodeSize returns the amount of memory in bytes required to store a single vector in the index.
+	CodeSize() (uint64, error)
+
 	// cPtr returns a pointer to the underlying C index struct.
 	cPtr() *C.FaissIndex
 
@@ -163,6 +166,14 @@ func (idx *faissIndex) IndexSize() (uint64, error) {
 		return 0, getLastError()
 	}
 	return uint64(size), nil
+}
+
+func (idx *faissIndex) CodeSize() (uint64, error) {
+	var codeSize C.size_t
+	if code := C.faiss_Index_sa_code_size(idx.idx, &codeSize); code != 0 {
+		return 0, getLastError()
+	}
+	return uint64(codeSize), nil
 }
 
 func (idx *faissIndex) D() int {

--- a/index.go
+++ b/index.go
@@ -14,9 +14,17 @@ import "C"
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"sort"
 	"unsafe"
 )
+
+var reflectStaticSizefaissIndex uint64
+
+func init() {
+	var f faissIndex
+	reflectStaticSizefaissIndex = uint64(reflect.TypeOf(f).Size())
+}
 
 // Index is a Faiss index.
 //
@@ -120,9 +128,15 @@ type Index interface {
 	// Close frees the memory used by the index.
 	Close()
 
-	// consults the C++ side to get the size of the index
+	// Size returns the Go struct size, excluding the C index memory.
+	// Suitable for memory-mapped indexes where the C memory is not RAM-resident.
 	Size() uint64
 
+	// IndexSize returns the RAM footprint of the C index as reported by FAISS.
+	// Use this when the index is fully loaded in memory (e.g. after a GPU clone).
+	IndexSize() (uint64, error)
+
+	// cPtr returns a pointer to the underlying C index struct.
 	cPtr() *C.FaissIndex
 
 	// set the quantizers from a source index into this index, applicable only
@@ -139,11 +153,15 @@ func (idx *faissIndex) cPtr() *C.FaissIndex {
 }
 
 func (idx *faissIndex) Size() uint64 {
+	return reflectStaticSizefaissIndex
+}
+
+func (idx *faissIndex) IndexSize() (uint64, error) {
 	var size C.size_t
 	if code := C.faiss_Index_size(idx.idx, &size); code != 0 {
-		return 0
+		return 0, getLastError()
 	}
-	return uint64(size)
+	return uint64(size), nil
 }
 
 func (idx *faissIndex) D() int {

--- a/index_binary.go
+++ b/index_binary.go
@@ -403,7 +403,10 @@ func (b *faissBinaryIndex) SearchClustersFromIVFIndex(eligibleCentroidIDs []int6
 }
 
 func (b *faissBinaryIndex) Size() uint64 {
-	size := C.faiss_IndexBinary_size(b.bIdx)
+	var size C.size_t
+	if code := C.faiss_IndexBinary_size(b.bIdx, &size); code != 0 {
+		return 0
+	}
 	return uint64(size)
 }
 

--- a/index_binary.go
+++ b/index_binary.go
@@ -96,12 +96,13 @@ type BinaryIndex interface {
 		centroidsToProbe int, xb []uint8, k int64, include Selector,
 		params json.RawMessage) ([]int32, []int64, error)
 
-	// Size returns the Go struct size, excluding the C index memory.
-	// Suitable for memory-mapped indexes where the C memory is memory-mapped.
+	// Size estimates the memory footprint of the index assuming in bytes,
+	// if the underlying faiss index is memory-mapped and not fully loaded into memory.
 	Size() uint64
 
-	// IndexSize returns the RAM footprint of the C index as reported by FAISS.
-	// Use this when the index is fully loaded in memory and not memory-mapped.
+	// IndexSize estimates the RAM footprint of the index in bytes,
+	// if the index is um-mapped and fully loaded into memory.
+	// This is a best effort estimation and may not be exact.
 	IndexSize() (uint64, error)
 
 	// frees the memory associated with the index

--- a/index_binary.go
+++ b/index_binary.go
@@ -105,6 +105,9 @@ type BinaryIndex interface {
 	// This is a best effort estimation and may not be exact.
 	IndexSize() (uint64, error)
 
+	// CodeSize returns the amount of memory in bytes required to store a single vector in the index.
+	CodeSize() uint64
+
 	// frees the memory associated with the index
 	Close()
 
@@ -427,6 +430,10 @@ func (b *faissBinaryIndex) IndexSize() (uint64, error) {
 		return 0, getLastError()
 	}
 	return uint64(size), nil
+}
+
+func (b *faissBinaryIndex) CodeSize() uint64 {
+	return uint64(C.faiss_IndexBinary_code_size(b.bIdx))
 }
 
 func (idx *faissBinaryIndex) Close() {

--- a/index_binary.go
+++ b/index_binary.go
@@ -13,8 +13,16 @@ import "C"
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"unsafe"
 )
+
+var reflectStaticSizefaissBinaryIndex uint64
+
+func init() {
+	var f faissBinaryIndex
+	reflectStaticSizefaissBinaryIndex = uint64(reflect.TypeOf(f).Size())
+}
 
 type BinaryIndex interface {
 	// D returns the dimension of the indexed vectors.
@@ -88,12 +96,18 @@ type BinaryIndex interface {
 		centroidsToProbe int, xb []uint8, k int64, include Selector,
 		params json.RawMessage) ([]int32, []int64, error)
 
-	// returns the total size of the index in bytes
+	// Size returns the Go struct size, excluding the C index memory.
+	// Suitable for memory-mapped indexes where the C memory is memory-mapped.
 	Size() uint64
+
+	// IndexSize returns the RAM footprint of the C index as reported by FAISS.
+	// Use this when the index is fully loaded in memory and not memory-mapped.
+	IndexSize() (uint64, error)
 
 	// frees the memory associated with the index
 	Close()
 
+	// bPtr returns a pointer to the underlying C index struct.
 	bPtr() *C.FaissIndexBinary
 }
 
@@ -403,11 +417,15 @@ func (b *faissBinaryIndex) SearchClustersFromIVFIndex(eligibleCentroidIDs []int6
 }
 
 func (b *faissBinaryIndex) Size() uint64 {
+	return reflectStaticSizefaissBinaryIndex
+}
+
+func (b *faissBinaryIndex) IndexSize() (uint64, error) {
 	var size C.size_t
 	if code := C.faiss_IndexBinary_size(b.bIdx, &size); code != 0 {
-		return 0
+		return 0, getLastError()
 	}
-	return uint64(size)
+	return uint64(size), nil
 }
 
 func (idx *faissBinaryIndex) Close() {


### PR DESCRIPTION
- Serialize GPU clones per device via a new `gpuSerializer` (per-device mutex), preventing concurrent `CloneToGPU` calls from oversubscribing the same GPU.
- Enforce memory check at clone time with a fresh `getFreeGPUMemory` reading taken under the scheduler lock, fixing the Time-of-Check to Time-of-Use (TOCTOU) race condition where stale load-balancer readings let concurrent callers all pass the threshold.
- Use an estimate of the amount of memory required on the GPU for the clone operation, to ensure that post the clone operation we have atleast `defaultGPUMinFreeMemory` memory available for the sake of temporary allocations during the index lifetime.
- Requires:
    - https://github.com/blevesearch/zapx/pull/408
    - https://github.com/blevesearch/faiss/pull/75
    - https://github.com/blevesearch/go-faiss/pull/62
- Debug logs comparing the estimated memory required on the GPU pre-clone and the actual memory used on the GPU post the clone operation.
```
---------------------------------
clone gpu=0   pre=  5646 MB  est=    20 MB  post=  5506 MB  actual=   140 MB  diff=+120 MB
clone gpu=0   pre=  5506 MB  est=    20 MB  post=  5498 MB  actual=     8 MB  diff=-12 MB
clone gpu=0   pre=  5498 MB  est=    41 MB  post=  5486 MB  actual=    12 MB  diff=-29 MB
clone gpu=0   pre=  5486 MB  est=   184 MB  post=  5214 MB  actual=   272 MB  diff=+88 MB
clone gpu=0   pre=  5214 MB  est=    20 MB  post=  5204 MB  actual=    10 MB  diff=-10 MB
clone gpu=0   pre=  5204 MB  est=    41 MB  post=  5194 MB  actual=    10 MB  diff=-31 MB
clone gpu=0   pre=  5194 MB  est=    82 MB  post=  5052 MB  actual=   142 MB  diff=+60 MB
clone gpu=0   pre=  5052 MB  est=    20 MB  post=  5044 MB  actual=     8 MB  diff=-12 MB
clone gpu=0   pre=  5044 MB  est=   204 MB  post=  4772 MB  actual=   272 MB  diff=+68 MB
clone gpu=0   pre=  4772 MB  est=   184 MB  post=  4500 MB  actual=   272 MB  diff=+88 MB
clone gpu=0   pre=  4500 MB  est=   204 MB  post=  4226 MB  actual=   274 MB  diff=+70 MB
clone gpu=0   pre=  4226 MB  est=   204 MB  post=  4082 MB  actual=   144 MB  diff=-60 MB
clone gpu=0   pre=  4082 MB  est=   204 MB  post=  3808 MB  actual=   274 MB  diff=+70 MB
clone gpu=0   pre=  3808 MB  est=   204 MB  post=  3536 MB  actual=   272 MB  diff=+68 MB
clone gpu=0   pre=  3536 MB  est=   204 MB  post=  3260 MB  actual=   276 MB  diff=+72 MB
clone gpu=0   pre=  3260 MB  est=   204 MB  post=  2988 MB  actual=   272 MB  diff=+68 MB
clone gpu=0   pre=  2988 MB  est=  1994 MB  post=   900 MB  actual=  2088 MB  diff=+94 MB
clone gpu=0   pre=   900 MB  est=  1994 MB  REJECTED (free < est + 512 MB buffer)
clone gpu=0   pre=   900 MB  est=  1994 MB  REJECTED (free < est + 512 MB buffer)
clone gpu=0   pre=   900 MB  est=  1994 MB  REJECTED (free < est + 512 MB buffer)
```