### PR TITLE
MB-71397: Fix size calculation for FAISS Indexes

### DIFF
--- a/gpu.go
+++ b/gpu.go
@@ -29,6 +29,7 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
+	"reflect"
 	"sort"
 	"sync"
 	"sync/atomic"
@@ -63,11 +64,15 @@ const (
 )
 
 var (
-	gpuCount     int
-	loadBalancer *gpuLoadBalancer
+	gpuCount                      int
+	loadBalancer                  *gpuLoadBalancer
+	reflectStaticSizeGPUIndexImpl uint64
 )
 
 func init() {
+	var f GPUIndexImpl
+	reflectStaticSizeGPUIndexImpl = uint64(reflect.TypeOf(f).Size())
+
 	var err error
 	gpuCount, err = numGPUs()
 	if err != nil || gpuCount <= 0 {
@@ -195,7 +200,6 @@ func getBestGPUDevice() (int, error) {
 	return loadBalancer.nextDevice()
 }
 
-// only expose API used by zapx
 type GPUIndexImpl struct {
 	idx         *faissIndex
 	gpuResource *C.FaissStandardGpuResources
@@ -226,6 +230,10 @@ func (g *GPUIndexImpl) Close() {
 		C.faiss_StandardGpuResources_free(g.gpuResource)
 		g.gpuResource = nil
 	}
+}
+
+func (g *GPUIndexImpl) Size() uint64 {
+	return reflectStaticSizeGPUIndexImpl + g.idx.Size()
 }
 
 // CloneToGPU transfers a CPU index to the best available GPU based on free memory.

--- a/gpu_stub.go
+++ b/gpu_stub.go
@@ -27,7 +27,8 @@ func (g *GPUIndexImpl) Add(x []float32) error   { return errGPUNotBuilt }
 func (g *GPUIndexImpl) Search(x []float32, k int64) ([]float32, []int64, error) {
 	return nil, nil, errGPUNotBuilt
 }
-func (g *GPUIndexImpl) Close() {}
+func (g *GPUIndexImpl) Close()       {}
+func (g *GPUIndexImpl) Size() uint64 { return 0 }
 
 var errGPUNotBuilt = errors.New("not built with GPU support (requires -tags gpu)")
 

--- a/index.go
+++ b/index.go
@@ -139,7 +139,10 @@ func (idx *faissIndex) cPtr() *C.FaissIndex {
 }
 
 func (idx *faissIndex) Size() uint64 {
-	size := C.faiss_Index_size(idx.idx)
+	var size C.size_t
+	if code := C.faiss_Index_size(idx.idx, &size); code != 0 {
+		return 0
+	}
 	return uint64(size)
 }
 

--- a/index.go
+++ b/index.go
@@ -128,12 +128,13 @@ type Index interface {
 	// Close frees the memory used by the index.
 	Close()
 
-	// Size returns the Go struct size, excluding the C index memory.
-	// Suitable for memory-mapped indexes where the C memory is not RAM-resident.
+	// Size estimates the memory footprint of the index assuming in bytes,
+	// if the underlying faiss index is memory-mapped and not fully loaded into memory.
 	Size() uint64
 
-	// IndexSize returns the RAM footprint of the C index as reported by FAISS.
-	// Use this when the index is fully loaded in memory (e.g. after a GPU clone).
+	// IndexSize estimates the RAM footprint of the index in bytes,
+	// if the index is um-mapped and fully loaded into memory.
+	// This is a best effort estimation and may not be exact.
 	IndexSize() (uint64, error)
 
 	// cPtr returns a pointer to the underlying C index struct.

--- a/index.go
+++ b/index.go
@@ -128,12 +128,12 @@ type Index interface {
 	// Close frees the memory used by the index.
 	Close()
 
-	// Size estimates the memory footprint of the index assuming in bytes,
+	// Size estimates the memory footprint of the index in bytes,
 	// if the underlying faiss index is memory-mapped and not fully loaded into memory.
 	Size() uint64
 
 	// IndexSize estimates the RAM footprint of the index in bytes,
-	// if the index is um-mapped and fully loaded into memory.
+	// if the index is unmapped and fully loaded into memory.
 	// This is a best effort estimation and may not be exact.
 	IndexSize() (uint64, error)
 

--- a/index.go
+++ b/index.go
@@ -19,11 +19,11 @@ import (
 	"unsafe"
 )
 
-var reflectStaticSizefaissIndex uint64
+var reflectStaticSizeFaissIndex uint64
 
 func init() {
 	var f faissIndex
-	reflectStaticSizefaissIndex = uint64(reflect.TypeOf(f).Size())
+	reflectStaticSizeFaissIndex = uint64(reflect.TypeOf(f).Size())
 }
 
 // Index is a Faiss index.
@@ -154,7 +154,12 @@ func (idx *faissIndex) cPtr() *C.FaissIndex {
 }
 
 func (idx *faissIndex) Size() uint64 {
-	return reflectStaticSizefaissIndex
+	rv := reflectStaticSizeFaissIndex
+	var size C.size_t
+	if code := C.faiss_Index_static_size(idx.idx, &size); code == 0 {
+		rv += uint64(size)
+	}
+	return rv
 }
 
 func (idx *faissIndex) IndexSize() (uint64, error) {

--- a/index.go
+++ b/index.go
@@ -132,11 +132,6 @@ type Index interface {
 	// if the underlying faiss index is memory-mapped and not fully loaded into memory.
 	Size() uint64
 
-	// IndexSize estimates the RAM footprint of the index in bytes,
-	// if the index is unmapped and fully loaded into memory.
-	// This is a best effort estimation and may not be exact.
-	IndexSize() (uint64, error)
-
 	// cPtr returns a pointer to the underlying C index struct.
 	cPtr() *C.FaissIndex
 
@@ -156,18 +151,10 @@ func (idx *faissIndex) cPtr() *C.FaissIndex {
 func (idx *faissIndex) Size() uint64 {
 	rv := reflectStaticSizeFaissIndex
 	var size C.size_t
-	if code := C.faiss_Index_static_size(idx.idx, &size); code == 0 {
+	if code := C.faiss_Index_size(idx.idx, &size); code == 0 {
 		rv += uint64(size)
 	}
 	return rv
-}
-
-func (idx *faissIndex) IndexSize() (uint64, error) {
-	var size C.size_t
-	if code := C.faiss_Index_size(idx.idx, &size); code != 0 {
-		return 0, getLastError()
-	}
-	return uint64(size), nil
 }
 
 func (idx *faissIndex) D() int {

--- a/index.go
+++ b/index.go
@@ -14,9 +14,17 @@ import "C"
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"sort"
 	"unsafe"
 )
+
+var reflectStaticSizefaissIndex uint64
+
+func init() {
+	var f faissIndex
+	reflectStaticSizefaissIndex = uint64(reflect.TypeOf(f).Size())
+}
 
 // Index is a Faiss index.
 //
@@ -120,9 +128,15 @@ type Index interface {
 	// Close frees the memory used by the index.
 	Close()
 
-	// consults the C++ side to get the size of the index
+	// Size returns the Go struct size, excluding the C index memory.
+	// Suitable for memory-mapped indexes where the C memory is not RAM-resident.
 	Size() uint64
 
+	// IndexSize returns the RAM footprint of the C index as reported by FAISS.
+	// Use this when the index is fully loaded in memory (e.g. after a GPU clone).
+	IndexSize() (uint64, error)
+
+	// cPtr returns a pointer to the underlying C index struct.
 	cPtr() *C.FaissIndex
 
 	// set the quantizers from a source index into this index, applicable only
@@ -139,11 +153,15 @@ func (idx *faissIndex) cPtr() *C.FaissIndex {
 }
 
 func (idx *faissIndex) Size() uint64 {
+	return reflectStaticSizefaissIndex
+}
+
+func (idx *faissIndex) IndexSize() (uint64, error) {
 	var size C.size_t
 	if code := C.faiss_Index_size(idx.idx, &size); code != 0 {
-		return 0
+		return 0, getLastError()
 	}
-	return uint64(size)
+	return uint64(size), nil
 }
 
 func (idx *faissIndex) D() int {

--- a/index_binary.go
+++ b/index_binary.go
@@ -403,7 +403,10 @@ func (b *faissBinaryIndex) SearchClustersFromIVFIndex(eligibleCentroidIDs []int6
 }
 
 func (b *faissBinaryIndex) Size() uint64 {
-	size := C.faiss_IndexBinary_size(b.bIdx)
+	var size C.size_t
+	if code := C.faiss_IndexBinary_size(b.bIdx, &size); code != 0 {
+		return 0
+	}
 	return uint64(size)
 }
 

--- a/index_binary.go
+++ b/index_binary.go
@@ -100,11 +100,6 @@ type BinaryIndex interface {
 	// if the underlying faiss index is memory-mapped and not fully loaded into memory.
 	Size() uint64
 
-	// IndexSize estimates the RAM footprint of the index in bytes,
-	// if the index is unmapped and fully loaded into memory.
-	// This is a best effort estimation and may not be exact.
-	IndexSize() (uint64, error)
-
 	// frees the memory associated with the index
 	Close()
 
@@ -420,18 +415,10 @@ func (b *faissBinaryIndex) SearchClustersFromIVFIndex(eligibleCentroidIDs []int6
 func (b *faissBinaryIndex) Size() uint64 {
 	rv := reflectStaticSizeFaissBinaryIndex
 	var size C.size_t
-	if code := C.faiss_IndexBinary_static_size(b.bIdx, &size); code == 0 {
+	if code := C.faiss_IndexBinary_size(b.bIdx, &size); code == 0 {
 		rv += uint64(size)
 	}
 	return rv
-}
-
-func (b *faissBinaryIndex) IndexSize() (uint64, error) {
-	var size C.size_t
-	if code := C.faiss_IndexBinary_size(b.bIdx, &size); code != 0 {
-		return 0, getLastError()
-	}
-	return uint64(size), nil
 }
 
 func (idx *faissBinaryIndex) Close() {

--- a/index_binary.go
+++ b/index_binary.go
@@ -17,11 +17,11 @@ import (
 	"unsafe"
 )
 
-var reflectStaticSizefaissBinaryIndex uint64
+var reflectStaticSizeFaissBinaryIndex uint64
 
 func init() {
-	var f faissBinaryIndex
-	reflectStaticSizefaissBinaryIndex = uint64(reflect.TypeOf(f).Size())
+	var b faissBinaryIndex
+	reflectStaticSizeFaissBinaryIndex = uint64(reflect.TypeOf(b).Size())
 }
 
 type BinaryIndex interface {
@@ -418,7 +418,12 @@ func (b *faissBinaryIndex) SearchClustersFromIVFIndex(eligibleCentroidIDs []int6
 }
 
 func (b *faissBinaryIndex) Size() uint64 {
-	return reflectStaticSizefaissBinaryIndex
+	rv := reflectStaticSizeFaissBinaryIndex
+	var size C.size_t
+	if code := C.faiss_IndexBinary_static_size(b.bIdx, &size); code == 0 {
+		rv += uint64(size)
+	}
+	return rv
 }
 
 func (b *faissBinaryIndex) IndexSize() (uint64, error) {

--- a/index_binary.go
+++ b/index_binary.go
@@ -96,12 +96,13 @@ type BinaryIndex interface {
 		centroidsToProbe int, xb []uint8, k int64, include Selector,
 		params json.RawMessage) ([]int32, []int64, error)
 
-	// Size returns the Go struct size, excluding the C index memory.
-	// Suitable for memory-mapped indexes where the C memory is memory-mapped.
+	// Size estimates the memory footprint of the index assuming in bytes,
+	// if the underlying faiss index is memory-mapped and not fully loaded into memory.
 	Size() uint64
 
-	// IndexSize returns the RAM footprint of the C index as reported by FAISS.
-	// Use this when the index is fully loaded in memory and not memory-mapped.
+	// IndexSize estimates the RAM footprint of the index in bytes,
+	// if the index is um-mapped and fully loaded into memory.
+	// This is a best effort estimation and may not be exact.
 	IndexSize() (uint64, error)
 
 	// frees the memory associated with the index

--- a/index_binary.go
+++ b/index_binary.go
@@ -13,8 +13,16 @@ import "C"
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"unsafe"
 )
+
+var reflectStaticSizefaissBinaryIndex uint64
+
+func init() {
+	var f faissBinaryIndex
+	reflectStaticSizefaissBinaryIndex = uint64(reflect.TypeOf(f).Size())
+}
 
 type BinaryIndex interface {
 	// D returns the dimension of the indexed vectors.
@@ -88,12 +96,18 @@ type BinaryIndex interface {
 		centroidsToProbe int, xb []uint8, k int64, include Selector,
 		params json.RawMessage) ([]int32, []int64, error)
 
-	// returns the total size of the index in bytes
+	// Size returns the Go struct size, excluding the C index memory.
+	// Suitable for memory-mapped indexes where the C memory is memory-mapped.
 	Size() uint64
+
+	// IndexSize returns the RAM footprint of the C index as reported by FAISS.
+	// Use this when the index is fully loaded in memory and not memory-mapped.
+	IndexSize() (uint64, error)
 
 	// frees the memory associated with the index
 	Close()
 
+	// bPtr returns a pointer to the underlying C index struct.
 	bPtr() *C.FaissIndexBinary
 }
 
@@ -403,11 +417,15 @@ func (b *faissBinaryIndex) SearchClustersFromIVFIndex(eligibleCentroidIDs []int6
 }
 
 func (b *faissBinaryIndex) Size() uint64 {
+	return reflectStaticSizefaissBinaryIndex
+}
+
+func (b *faissBinaryIndex) IndexSize() (uint64, error) {
 	var size C.size_t
 	if code := C.faiss_IndexBinary_size(b.bIdx, &size); code != 0 {
-		return 0
+		return 0, getLastError()
 	}
-	return uint64(size)
+	return uint64(size), nil
 }
 
 func (idx *faissBinaryIndex) Close() {

--- a/index_binary.go
+++ b/index_binary.go
@@ -96,12 +96,12 @@ type BinaryIndex interface {
 		centroidsToProbe int, xb []uint8, k int64, include Selector,
 		params json.RawMessage) ([]int32, []int64, error)
 
-	// Size estimates the memory footprint of the index assuming in bytes,
+	// Size estimates the memory footprint of the index in bytes
 	// if the underlying faiss index is memory-mapped and not fully loaded into memory.
 	Size() uint64
 
 	// IndexSize estimates the RAM footprint of the index in bytes,
-	// if the index is um-mapped and fully loaded into memory.
+	// if the index is unmapped and fully loaded into memory.
 	// This is a best effort estimation and may not be exact.
 	IndexSize() (uint64, error)
 


### PR DESCRIPTION
- Use the new `faiss_Index_size()` FAISS method in the `Size()` API for 
  Binary and FP32 index classes.
- Add missing `Size()` API for the GPU Index class.