### PR TITLE
MB-71397: Add Go binding for code size

### DIFF
--- a/index.go
+++ b/index.go
@@ -138,6 +138,9 @@ type Index interface {
 	// set the quantizers from a source index into this index, applicable only
 	// for IVF indexes
 	SetQuantizers(source Index) error
+
+	// CodeSize returns the size of the produced codes in bytes.
+	CodeSize() (int, error)
 }
 
 type faissIndex struct {
@@ -159,6 +162,14 @@ func (idx *faissIndex) Size() uint64 {
 
 func (idx *faissIndex) D() int {
 	return int(C.faiss_Index_d(idx.idx))
+}
+
+func (idx *faissIndex) CodeSize() (int, error) {
+	var size C.size_t
+	if c := C.faiss_Index_sa_code_size(idx.idx, &size); c != 0 {
+		return 0, getLastError()
+	}
+	return int(size), nil
 }
 
 func (idx *faissIndex) IsTrained() bool {

--- a/index.go
+++ b/index.go
@@ -140,7 +140,7 @@ type Index interface {
 	SetQuantizers(source Index) error
 
 	// CodeSize returns the size of the produced codes in bytes.
-	CodeSize() (int, error)
+	CodeSize() (uint64, error)
 }
 
 type faissIndex struct {
@@ -164,12 +164,12 @@ func (idx *faissIndex) D() int {
 	return int(C.faiss_Index_d(idx.idx))
 }
 
-func (idx *faissIndex) CodeSize() (int, error) {
+func (idx *faissIndex) CodeSize() (uint64, error) {
 	var size C.size_t
 	if c := C.faiss_Index_sa_code_size(idx.idx, &size); c != 0 {
 		return 0, getLastError()
 	}
-	return int(size), nil
+	return uint64(size), nil
 }
 
 func (idx *faissIndex) IsTrained() bool {

--- a/index_binary.go
+++ b/index_binary.go
@@ -107,7 +107,7 @@ type BinaryIndex interface {
 	bPtr() *C.FaissIndexBinary
 
 	// CodeSize returns the size of the produced codes in bytes.
-	CodeSize() (int, error)
+	CodeSize() (uint64, error)
 }
 
 type faissBinaryIndex struct {
@@ -424,12 +424,12 @@ func (b *faissBinaryIndex) Size() uint64 {
 	return rv
 }
 
-func (b *faissBinaryIndex) CodeSize() (int, error) {
+func (b *faissBinaryIndex) CodeSize() (uint64, error) {
 	var size C.size_t
 	if c := C.faiss_IndexBinary_code_size(b.bIdx, &size); c != 0 {
 		return 0, getLastError()
 	}
-	return int(size), nil
+	return uint64(size), nil
 }
 
 func (idx *faissBinaryIndex) Close() {

--- a/index_binary.go
+++ b/index_binary.go
@@ -426,7 +426,7 @@ func (b *faissBinaryIndex) Size() uint64 {
 
 func (b *faissBinaryIndex) CodeSize() (uint64, error) {
 	var size C.size_t
-	if c := C.faiss_IndexBinary_code_size(b.bIdx, &size); c != 0 {
+	if c := C.faiss_IndexBinary_sa_code_size(b.bIdx, &size); c != 0 {
 		return 0, getLastError()
 	}
 	return uint64(size), nil

--- a/index_binary.go
+++ b/index_binary.go
@@ -105,6 +105,9 @@ type BinaryIndex interface {
 
 	// bPtr returns a pointer to the underlying C index struct.
 	bPtr() *C.FaissIndexBinary
+
+	// CodeSize returns the size of the produced codes in bytes.
+	CodeSize() (int, error)
 }
 
 type faissBinaryIndex struct {
@@ -419,6 +422,14 @@ func (b *faissBinaryIndex) Size() uint64 {
 		rv += uint64(size)
 	}
 	return rv
+}
+
+func (b *faissBinaryIndex) CodeSize() (int, error) {
+	var size C.size_t
+	if c := C.faiss_IndexBinary_code_size(b.bIdx, &size); c != 0 {
+		return 0, getLastError()
+	}
+	return int(size), nil
 }
 
 func (idx *faissBinaryIndex) Close() {


### PR DESCRIPTION
- Add a go binding to get the size of a single encoded vector from the underlying FAISS index.