### PR TITLE
MB-71397: Add FAISS error package

### DIFF
--- a/autotune.go
+++ b/autotune.go
@@ -33,7 +33,7 @@ func (p *ParameterSpace) SetIndexParameter(idx Index, name string, val float64) 
 	c := C.faiss_ParameterSpace_set_index_parameter(
 		p.ps, idx.cPtr(), cname, C.double(val))
 	if c != 0 {
-		return NewError(ErrCreateParamsFailed, int(c))
+		return NewError(ErrSetParamsFailed, int(c))
 	}
 	return nil
 }

--- a/autotune.go
+++ b/autotune.go
@@ -17,7 +17,7 @@ type ParameterSpace struct {
 func NewParameterSpace() (*ParameterSpace, error) {
 	var ps *C.FaissParameterSpace
 	if c := C.faiss_ParameterSpace_new(&ps); c != 0 {
-		return nil, getLastError()
+		return nil, NewError(ErrCreateParamsFailed, int(c))
 	}
 	return &ParameterSpace{ps}, nil
 }
@@ -33,7 +33,7 @@ func (p *ParameterSpace) SetIndexParameter(idx Index, name string, val float64) 
 	c := C.faiss_ParameterSpace_set_index_parameter(
 		p.ps, idx.cPtr(), cname, C.double(val))
 	if c != 0 {
-		return getLastError()
+		return NewError(ErrCreateParamsFailed, int(c))
 	}
 	return nil
 }

--- a/autotune.go
+++ b/autotune.go
@@ -17,7 +17,7 @@ type ParameterSpace struct {
 func NewParameterSpace() (*ParameterSpace, error) {
 	var ps *C.FaissParameterSpace
 	if c := C.faiss_ParameterSpace_new(&ps); c != 0 {
-		return nil, NewError(ErrCreateParamsFailed, int(c))
+		return nil, newFaissError(ErrCreateParamsFailed, getLastError(), int(c))
 	}
 	return &ParameterSpace{ps}, nil
 }
@@ -33,7 +33,7 @@ func (p *ParameterSpace) SetIndexParameter(idx Index, name string, val float64) 
 	c := C.faiss_ParameterSpace_set_index_parameter(
 		p.ps, idx.cPtr(), cname, C.double(val))
 	if c != 0 {
-		return NewError(ErrSetParamsFailed, int(c))
+		return newFaissError(ErrSetParamsFailed, getLastError(), int(c))
 	}
 	return nil
 }

--- a/errors.go
+++ b/errors.go
@@ -1,51 +1,44 @@
 package faiss
 
+/*
+#include <faiss/c_api/error_c.h>
+*/
+import "C"
 import (
 	"errors"
 	"fmt"
 )
 
-// Error pairs a go-faiss sentinel error with the integer error code returned
-// by the underlying FAISS C call. It supports errors.Is against the sentinel
-// (via Unwrap) and exposes the raw C return code for callers that want it.
-type Error struct {
-	Err  error // sentinel: one of the package-level Err* values
-	Code int   // the non-zero return code from the failing C function
+// faissError wraps an error returned by a faiss C API call,
+// including the error type and the error code returned by the C API.
+type faissError struct {
+	errType error
+	err     error
+	errCode int
 }
 
-func (e *Error) Error() string {
-	if e == nil || e.Err == nil {
-		return "faiss: <nil error>"
+func (e *faissError) Error() string {
+	return fmt.Sprintf("faiss error: %v (code: %d, type: %v)", e.err, e.errCode, e.errType)
+}
+
+// returns the error type which can allow usage of
+// errors.Is and errors.As for error handling.
+func (e *faissError) Unwrap() error {
+	if e.err != nil {
+		return e.errType
 	}
-	return fmt.Sprintf("%s (code %d)", e.Err.Error(), e.Code)
+	return nil
 }
 
-func (e *Error) Unwrap() error {
-	if e == nil {
-		return nil
+func newFaissError(errType, err error, errCode int) error {
+	return &faissError{
+		errType: errType,
+		err:     err,
+		errCode: errCode,
 	}
-	return e.Err
 }
 
-func NewError(sentinel error, code int) error {
-	return &Error{Err: sentinel, Code: code}
-}
-
-// Sentinel errors returned by go-faiss.
-//
-// These are deliberately fixed, package-level values so that:
-//
-//  1. Callers can use errors.Is to identify the failing operation class.
-//  2. We avoid reading the FAISS C-side global error string via
-//     faiss_get_last_error(), which is racy under concurrent use:
-//     another goroutine/thread may overwrite that global between the
-//     failing C call and our read, yielding a wrong (or empty) message.
-//
-// Style:
-//   - Operation errors are phrased as "faiss: <verb> <noun> failed"
-//     and their identifier ends in "Failed".
-//   - State / pre-condition errors are a declarative phrase
-//     ("faiss: index is not an ivf index") with no "Failed" suffix.
+// FAISS error types for categorizing errors returned by the C API.
 var (
 	// ---- Construction ----
 	ErrCreateIndexFailed    = errors.New("faiss: create index failed")
@@ -65,7 +58,7 @@ var (
 	ErrMergeFromFailed    = errors.New("faiss: merge from index failed")
 	ErrRemoveIDsFailed    = errors.New("faiss: remove ids failed")
 
-	// ---- Read-only index introspection (NOT search) ----
+	// ---- Read-only index introspection ----
 	ErrInspectIndexFailed = errors.New("faiss: inspect index failed")
 
 	// ---- I/O ----
@@ -88,3 +81,13 @@ var (
 	ErrMergeFromNotSupported    = errors.New("faiss: merge from is only supported for IVF indices")
 	ErrSetQuantizerNotSupported = errors.New("faiss: set quantizer not supported for this index type")
 )
+
+// getLastError returns the last error message set by the FAISS C API.
+//
+// The underlying C variable is thread-local / global and can be clobbered
+// by concurrent FAISS calls or by goroutine rescheduling across OS threads,
+// so this string is best-effort diagnostic context only. Always use the
+// errType sentinel (with errors.Is / errors.As) to identify the error.
+func getLastError() error {
+	return errors.New(C.GoString(C.faiss_get_last_error()))
+}

--- a/errors.go
+++ b/errors.go
@@ -39,7 +39,7 @@ func newFaissError(errType, err error, errCode int) error {
 var (
 	// ---- Construction ----
 	ErrCreateIndexFailed    = errors.New("faiss: create index failed")
-	ErrCreateSelectorFailed = errors.New("faiss: create id selector failed")
+	ErrCreateSelectorFailed = errors.New("faiss: create selector failed")
 
 	// ---- Configuration ----
 	ErrCreateParamsFailed = errors.New("faiss: create search params failed")
@@ -53,7 +53,7 @@ var (
 	ErrResetIndexFailed   = errors.New("faiss: reset index failed")
 	ErrSetQuantizerFailed = errors.New("faiss: set quantizer failed")
 	ErrMergeFromFailed    = errors.New("faiss: merge from index failed")
-	ErrRemoveIDsFailed    = errors.New("faiss: remove ids failed")
+	ErrRemoveIDsFailed    = errors.New("faiss: remove IDs failed")
 
 	// ---- Read-only index introspection ----
 	ErrInspectIndexFailed = errors.New("faiss: inspect index failed")
@@ -63,16 +63,16 @@ var (
 	ErrReadIndexFailed  = errors.New("faiss: read index failed")
 
 	// ---- GPU ----
-	ErrNoUsableGPUDevices = errors.New("faiss: no gpu usable devices available")
-	ErrGPUCloneFailed     = errors.New("faiss: gpu clone failed")
-	ErrGPUSetupFailed     = errors.New("faiss: gpu setup failed")
+	ErrNoUsableGPUDevices = errors.New("faiss: no GPU usable devices available")
+	ErrGPUCloneFailed     = errors.New("faiss: GPU clone failed")
+	ErrGPUSetupFailed     = errors.New("faiss: GPU setup failed")
 
 	// ---- State / pre-condition errors ----
 	ErrIndexNil      = errors.New("faiss: index is nil")
 	ErrSelectorNil   = errors.New("faiss: selector is nil")
-	ErrNotIDMapIndex = errors.New("faiss: index is not an idmap index")
-	ErrNotIVFIndex   = errors.New("faiss: index is not an ivf index")
-	ErrNotBIVFIndex  = errors.New("faiss: index is not a binary ivf index")
+	ErrNotIDMapIndex = errors.New("faiss: index is not an IDMap index")
+	ErrNotIVFIndex   = errors.New("faiss: index is not an IVF index")
+	ErrNotBIVFIndex  = errors.New("faiss: index is not a binary IVF index")
 
 	// ---- Unsupported operations ----
 	ErrMergeFromNotSupported    = errors.New("faiss: merge from is only supported for IVF indices")

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,88 @@
+package faiss
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Error pairs a go-faiss sentinel error with the integer error code returned
+// by the underlying FAISS C call. It supports errors.Is against the sentinel
+// (via Unwrap) and exposes the raw C return code for callers that want it.
+type Error struct {
+	Err  error // sentinel: one of the package-level Err* values
+	Code int   // the non-zero return code from the failing C function
+}
+
+func (e *Error) Error() string {
+	if e == nil || e.Err == nil {
+		return "faiss: <nil error>"
+	}
+	return fmt.Sprintf("%s (code %d)", e.Err.Error(), e.Code)
+}
+
+func (e *Error) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+func NewError(sentinel error, code int) error {
+	return &Error{Err: sentinel, Code: code}
+}
+
+// Sentinel errors returned by go-faiss.
+//
+// These are deliberately fixed, package-level values so that:
+//
+//  1. Callers can use errors.Is to identify the failing operation class.
+//  2. We avoid reading the FAISS C-side global error string via
+//     faiss_get_last_error(), which is racy under concurrent use:
+//     another goroutine/thread may overwrite that global between the
+//     failing C call and our read, yielding a wrong (or empty) message.
+//
+// Style:
+//   - Operation errors are phrased as "faiss: <verb> <noun> failed"
+//     and their identifier ends in "Failed".
+//   - State / pre-condition errors are a declarative phrase
+//     ("faiss: index is not an ivf index") with no "Failed" suffix.
+var (
+	// ---- Construction ----
+	ErrCreateIndexFailed    = errors.New("faiss: create index failed")
+	ErrCreateSelectorFailed = errors.New("faiss: create id selector failed")
+
+	// ---- Configuration ----
+	ErrCreateParamsFailed = errors.New("faiss: create search params failed")
+	ErrSetParamsFailed    = errors.New("faiss: set index params failed")
+
+	// ---- Lifecycle / configuration ----
+	ErrTrainIndexFailed = errors.New("faiss: train index failed")
+	ErrResetIndexFailed = errors.New("faiss: reset index failed")
+
+	// ---- Vector ops ----
+	ErrAddFailed         = errors.New("faiss: add vectors failed")
+	ErrSearchFailed      = errors.New("faiss: search index failed")
+	ErrReconstructFailed = errors.New("faiss: reconstruct vector failed")
+	ErrMergeFromFailed   = errors.New("faiss: merge from index failed")
+	ErrRemoveIDsFailed   = errors.New("faiss: remove ids failed")
+
+	// ---- Read-only index introspection (NOT search) ----
+	ErrInspectIndexFailed = errors.New("faiss: inspect index failed")
+
+	// ---- I/O ----
+	ErrWriteIndexFailed = errors.New("faiss: write index failed")
+	ErrReadIndexFailed  = errors.New("faiss: read index failed")
+
+	// ---- GPU ----
+	ErrGPUOperationFailed = errors.New("faiss: gpu operation failed")
+	ErrGPUCloneFailed     = errors.New("faiss: gpu clone failed")
+	ErrNoGPUDevices       = errors.New("faiss: no gpu devices available")
+
+	// ---- State / pre-condition (declarative; no "Failed" suffix) ----
+	ErrNotIVFIndex           = errors.New("faiss: index is not an ivf index")
+	ErrNotBIVFIndex          = errors.New("faiss: index is not a binary ivf index")
+	ErrMergeFromNotSupported = errors.New("faiss: merge from not supported for this index type")
+	ErrSourceIndexNil        = errors.New("faiss: source index is nil")
+	ErrIndexNil              = errors.New("faiss: index is nil")
+	ErrSelectorNil           = errors.New("faiss: selector is nil")
+)

--- a/errors.go
+++ b/errors.go
@@ -57,7 +57,7 @@ var (
 
 	// ---- Vector ops ----
 	ErrAddFailed          = errors.New("faiss: add vectors failed")
-	ErrTrainIndexFailed   = errors.New("faiss: train index failed")
+	ErrTrainFailed        = errors.New("faiss: train index failed")
 	ErrSearchFailed       = errors.New("faiss: search index failed")
 	ErrReconstructFailed  = errors.New("faiss: reconstruct vector failed")
 	ErrResetIndexFailed   = errors.New("faiss: reset index failed")
@@ -73,15 +73,15 @@ var (
 	ErrReadIndexFailed  = errors.New("faiss: read index failed")
 
 	// ---- GPU ----
-	ErrGPUOperationFailed = errors.New("faiss: gpu operation failed")
-	ErrGPUCloneFailed     = errors.New("faiss: gpu clone failed")
-	ErrNoGPUDevices       = errors.New("faiss: no gpu devices available")
+	ErrNoGPUDevices   = errors.New("faiss: no gpu devices available")
+	ErrGPUCloneFailed = errors.New("faiss: gpu operation failed")
 
 	// ---- State / pre-condition errors ----
-	ErrNotIVFIndex  = errors.New("faiss: index is not an ivf index")
-	ErrNotBIVFIndex = errors.New("faiss: index is not a binary ivf index")
-	ErrIndexNil     = errors.New("faiss: index is nil")
-	ErrSelectorNil  = errors.New("faiss: selector is nil")
+	ErrIndexNil      = errors.New("faiss: index is nil")
+	ErrSelectorNil   = errors.New("faiss: selector is nil")
+	ErrNotIDMapIndex = errors.New("faiss: index is not an idmap index")
+	ErrNotIVFIndex   = errors.New("faiss: index is not an ivf index")
+	ErrNotBIVFIndex  = errors.New("faiss: index is not a binary ivf index")
 
 	// ---- Unsupported operations ----
 	ErrMergeFromNotSupported    = errors.New("faiss: merge from is only supported for IVF indices")

--- a/errors.go
+++ b/errors.go
@@ -55,16 +55,15 @@ var (
 	ErrCreateParamsFailed = errors.New("faiss: create search params failed")
 	ErrSetParamsFailed    = errors.New("faiss: set index params failed")
 
-	// ---- Lifecycle / configuration ----
-	ErrTrainIndexFailed = errors.New("faiss: train index failed")
-	ErrResetIndexFailed = errors.New("faiss: reset index failed")
-
 	// ---- Vector ops ----
-	ErrAddFailed         = errors.New("faiss: add vectors failed")
-	ErrSearchFailed      = errors.New("faiss: search index failed")
-	ErrReconstructFailed = errors.New("faiss: reconstruct vector failed")
-	ErrMergeFromFailed   = errors.New("faiss: merge from index failed")
-	ErrRemoveIDsFailed   = errors.New("faiss: remove ids failed")
+	ErrAddFailed          = errors.New("faiss: add vectors failed")
+	ErrTrainIndexFailed   = errors.New("faiss: train index failed")
+	ErrSearchFailed       = errors.New("faiss: search index failed")
+	ErrReconstructFailed  = errors.New("faiss: reconstruct vector failed")
+	ErrResetIndexFailed   = errors.New("faiss: reset index failed")
+	ErrSetQuantizerFailed = errors.New("faiss: set quantizer failed")
+	ErrMergeFromFailed    = errors.New("faiss: merge from index failed")
+	ErrRemoveIDsFailed    = errors.New("faiss: remove ids failed")
 
 	// ---- Read-only index introspection (NOT search) ----
 	ErrInspectIndexFailed = errors.New("faiss: inspect index failed")
@@ -78,11 +77,13 @@ var (
 	ErrGPUCloneFailed     = errors.New("faiss: gpu clone failed")
 	ErrNoGPUDevices       = errors.New("faiss: no gpu devices available")
 
-	// ---- State / pre-condition (declarative; no "Failed" suffix) ----
-	ErrNotIVFIndex           = errors.New("faiss: index is not an ivf index")
-	ErrNotBIVFIndex          = errors.New("faiss: index is not a binary ivf index")
-	ErrMergeFromNotSupported = errors.New("faiss: merge from not supported for this index type")
-	ErrSourceIndexNil        = errors.New("faiss: source index is nil")
-	ErrIndexNil              = errors.New("faiss: index is nil")
-	ErrSelectorNil           = errors.New("faiss: selector is nil")
+	// ---- State / pre-condition errors ----
+	ErrNotIVFIndex  = errors.New("faiss: index is not an ivf index")
+	ErrNotBIVFIndex = errors.New("faiss: index is not a binary ivf index")
+	ErrIndexNil     = errors.New("faiss: index is nil")
+	ErrSelectorNil  = errors.New("faiss: selector is nil")
+
+	// ---- Unsupported operations ----
+	ErrMergeFromNotSupported    = errors.New("faiss: merge from is only supported for IVF indices")
+	ErrSetQuantizerNotSupported = errors.New("faiss: set quantizer not supported for this index type")
 )

--- a/errors.go
+++ b/errors.go
@@ -73,8 +73,8 @@ var (
 	ErrReadIndexFailed  = errors.New("faiss: read index failed")
 
 	// ---- GPU ----
-	ErrNoUsableGPUDevices = errors.New("faiss: no gpu devices available")
-	ErrGPUCloneFailed     = errors.New("faiss: gpu operation failed")
+	ErrNoUsableGPUDevices = errors.New("faiss: no gpu usable devices available")
+	ErrGPUCloneFailed     = errors.New("faiss: gpu clone failed")
 	ErrGPUSetupFailed     = errors.New("faiss: gpu setup failed")
 
 	// ---- State / pre-condition errors ----

--- a/errors.go
+++ b/errors.go
@@ -38,45 +38,45 @@ func newFaissError(errType, err error, errCode int) error {
 // FAISS error types for categorizing errors returned by the C API.
 var (
 	// ---- Construction ----
-	ErrCreateIndexFailed    = errors.New("faiss: create index failed")
-	ErrCreateSelectorFailed = errors.New("faiss: create selector failed")
+	ErrCreateIndexFailed    = errors.New("create index failed")
+	ErrCreateSelectorFailed = errors.New("create selector failed")
 
 	// ---- Configuration ----
-	ErrCreateParamsFailed = errors.New("faiss: create search params failed")
-	ErrSetParamsFailed    = errors.New("faiss: set index params failed")
+	ErrCreateParamsFailed = errors.New("create search params failed")
+	ErrSetParamsFailed    = errors.New("set index params failed")
 
 	// ---- Vector ops ----
-	ErrAddFailed          = errors.New("faiss: add vectors failed")
-	ErrTrainFailed        = errors.New("faiss: train index failed")
-	ErrSearchFailed       = errors.New("faiss: search index failed")
-	ErrReconstructFailed  = errors.New("faiss: reconstruct vector failed")
-	ErrResetIndexFailed   = errors.New("faiss: reset index failed")
-	ErrSetQuantizerFailed = errors.New("faiss: set quantizer failed")
-	ErrMergeFromFailed    = errors.New("faiss: merge from index failed")
-	ErrRemoveIDsFailed    = errors.New("faiss: remove IDs failed")
+	ErrAddFailed          = errors.New("add vectors failed")
+	ErrTrainFailed        = errors.New("train index failed")
+	ErrSearchFailed       = errors.New("search index failed")
+	ErrReconstructFailed  = errors.New("reconstruct vector failed")
+	ErrResetIndexFailed   = errors.New("reset index failed")
+	ErrSetQuantizerFailed = errors.New("set quantizer failed")
+	ErrMergeFromFailed    = errors.New("merge from index failed")
+	ErrRemoveIDsFailed    = errors.New("remove IDs failed")
 
 	// ---- Read-only index introspection ----
-	ErrInspectIndexFailed = errors.New("faiss: inspect index failed")
+	ErrInspectIndexFailed = errors.New("inspect index failed")
 
 	// ---- I/O ----
-	ErrWriteIndexFailed = errors.New("faiss: write index failed")
-	ErrReadIndexFailed  = errors.New("faiss: read index failed")
+	ErrWriteIndexFailed = errors.New("write index failed")
+	ErrReadIndexFailed  = errors.New("read index failed")
 
 	// ---- GPU ----
-	ErrNoUsableGPUDevices = errors.New("faiss: no GPU usable devices available")
-	ErrGPUCloneFailed     = errors.New("faiss: GPU clone failed")
-	ErrGPUSetupFailed     = errors.New("faiss: GPU setup failed")
+	ErrNoUsableGPUDevices = errors.New("no GPU usable devices available")
+	ErrGPUCloneFailed     = errors.New("GPU clone failed")
+	ErrGPUSetupFailed     = errors.New("GPU setup failed")
 
 	// ---- State / pre-condition errors ----
-	ErrIndexNil      = errors.New("faiss: index is nil")
-	ErrSelectorNil   = errors.New("faiss: selector is nil")
-	ErrNotIDMapIndex = errors.New("faiss: index is not an IDMap index")
-	ErrNotIVFIndex   = errors.New("faiss: index is not an IVF index")
-	ErrNotBIVFIndex  = errors.New("faiss: index is not a binary IVF index")
+	ErrIndexNil      = errors.New("index is nil")
+	ErrSelectorNil   = errors.New("selector is nil")
+	ErrNotIDMapIndex = errors.New("index is not an IDMap index")
+	ErrNotIVFIndex   = errors.New("index is not an IVF index")
+	ErrNotBIVFIndex  = errors.New("index is not a binary IVF index")
 
 	// ---- Unsupported operations ----
-	ErrMergeFromNotSupported    = errors.New("faiss: merge from is only supported for IVF indices")
-	ErrSetQuantizerNotSupported = errors.New("faiss: set quantizer not supported for this index type")
+	ErrMergeFromNotSupported    = errors.New("merge from is only supported for IVF indices")
+	ErrSetQuantizerNotSupported = errors.New("set quantizer not supported for this index type")
 )
 
 // getLastError returns the last error message set by the FAISS C API.

--- a/errors.go
+++ b/errors.go
@@ -73,8 +73,9 @@ var (
 	ErrReadIndexFailed  = errors.New("faiss: read index failed")
 
 	// ---- GPU ----
-	ErrNoGPUDevices   = errors.New("faiss: no gpu devices available")
-	ErrGPUCloneFailed = errors.New("faiss: gpu operation failed")
+	ErrNoUsableGPUDevices = errors.New("faiss: no gpu devices available")
+	ErrGPUCloneFailed     = errors.New("faiss: gpu operation failed")
+	ErrGPUSetupFailed     = errors.New("faiss: gpu setup failed")
 
 	// ---- State / pre-condition errors ----
 	ErrIndexNil      = errors.New("faiss: index is nil")

--- a/errors.go
+++ b/errors.go
@@ -18,7 +18,7 @@ type faissError struct {
 }
 
 func (e *faissError) Error() string {
-	return fmt.Sprintf("faiss error: %v (code: %d, type: %v)", e.err, e.errCode, e.errType)
+	return fmt.Sprintf("faiss %s: %s (code %d)", e.errType, e.err, e.errCode)
 }
 
 // returns the error type which can allow usage of
@@ -84,7 +84,7 @@ var (
 
 	// ---- Unsupported operations ----
 
-	ErrMergeFromNotSupported    = errors.New("merge from is only supported for IVF indices")
+	ErrMergeFromNotSupported    = errors.New("merge from is not supported for this index type")
 	ErrSetQuantizerNotSupported = errors.New("set quantizer not supported for this index type")
 )
 

--- a/errors.go
+++ b/errors.go
@@ -27,6 +27,7 @@ func (e *faissError) Unwrap() error {
 	return e.errType
 }
 
+// create a new faissError with the given error type, underlying error, and error code.
 func newFaissError(errType, err error, errCode int) error {
 	return &faissError{
 		errType: errType,
@@ -38,14 +39,17 @@ func newFaissError(errType, err error, errCode int) error {
 // FAISS error types for categorizing errors returned by the C API.
 var (
 	// ---- Construction ----
+
 	ErrCreateIndexFailed    = errors.New("create index failed")
 	ErrCreateSelectorFailed = errors.New("create selector failed")
 
 	// ---- Configuration ----
+
 	ErrCreateParamsFailed = errors.New("create search params failed")
 	ErrSetParamsFailed    = errors.New("set index params failed")
 
 	// ---- Vector ops ----
+
 	ErrAddFailed          = errors.New("add vectors failed")
 	ErrTrainFailed        = errors.New("train index failed")
 	ErrSearchFailed       = errors.New("search index failed")
@@ -56,18 +60,22 @@ var (
 	ErrRemoveIDsFailed    = errors.New("remove IDs failed")
 
 	// ---- Read-only index introspection ----
+
 	ErrInspectIndexFailed = errors.New("inspect index failed")
 
 	// ---- I/O ----
+
 	ErrWriteIndexFailed = errors.New("write index failed")
 	ErrReadIndexFailed  = errors.New("read index failed")
 
 	// ---- GPU ----
+
 	ErrNoUsableGPUDevices = errors.New("no GPU usable devices available")
 	ErrGPUCloneFailed     = errors.New("GPU clone failed")
 	ErrGPUSetupFailed     = errors.New("GPU setup failed")
 
 	// ---- State / pre-condition errors ----
+
 	ErrIndexNil      = errors.New("index is nil")
 	ErrSelectorNil   = errors.New("selector is nil")
 	ErrNotIDMapIndex = errors.New("index is not an IDMap index")
@@ -75,6 +83,7 @@ var (
 	ErrNotBIVFIndex  = errors.New("index is not a binary IVF index")
 
 	// ---- Unsupported operations ----
+
 	ErrMergeFromNotSupported    = errors.New("merge from is only supported for IVF indices")
 	ErrSetQuantizerNotSupported = errors.New("set quantizer not supported for this index type")
 )

--- a/errors.go
+++ b/errors.go
@@ -24,10 +24,7 @@ func (e *faissError) Error() string {
 // returns the error type which can allow usage of
 // errors.Is and errors.As for error handling.
 func (e *faissError) Unwrap() error {
-	if e.err != nil {
-		return e.errType
-	}
-	return nil
+	return e.errType
 }
 
 func newFaissError(errType, err error, errCode int) error {

--- a/faiss.go
+++ b/faiss.go
@@ -8,18 +8,9 @@ package faiss
 #cgo LDFLAGS: -lfaiss_c
 
 #include <faiss/c_api/Index_c.h>
-#include <faiss/c_api/error_c.h>
 #include <faiss/c_api/utils/distances_c.h>
 */
 import "C"
-import (
-	"errors"
-	"fmt"
-)
-
-func getLastError() error {
-	return errors.New(C.GoString(C.faiss_get_last_error()))
-}
 
 // Metric type
 const (
@@ -42,11 +33,3 @@ func NormalizeVector(vector []float32) []float32 {
 
 	return vector
 }
-
-var (
-	errNotIVFIndex           = fmt.Errorf("index is not of ivf type")
-	errMergeFromNotSupported = fmt.Errorf("merge api not supported")
-	errNotBIVFIndex          = fmt.Errorf("index is not of bivf type")
-	errFailedToSetQuantizers = fmt.Errorf("couldn't set the quantizers")
-	errSourceIndexNil        = fmt.Errorf("source index is nil")
-)

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/blevesearch/go-faiss
 
-go 1.21
+go 1.25.0

--- a/gpu.go
+++ b/gpu.go
@@ -242,7 +242,7 @@ func CloneToGPU(cpuIndex *IndexImpl) (*GPUIndexImpl, error) {
 
 	var gpuResource *C.FaissStandardGpuResources
 	if code := C.faiss_StandardGpuResources_new(&gpuResource); code != 0 {
-		return nil, NewError(ErrGPUOperationFailed, int(code))
+		return nil, NewError(ErrGPUCloneFailed, int(code))
 	}
 
 	// Disable the pre-allocated temp memory pool so that all GPU memory is
@@ -250,17 +250,17 @@ func CloneToGPU(cpuIndex *IndexImpl) (*GPUIndexImpl, error) {
 	// allocations via cudaMalloc/cudaFree on demand.
 	if code := C.faiss_StandardGpuResources_noTempMemory(gpuResource); code != 0 {
 		C.faiss_StandardGpuResources_free(gpuResource)
-		return nil, NewError(ErrGPUOperationFailed, int(code))
+		return nil, NewError(ErrGPUCloneFailed, int(code))
 	}
 	if code := C.faiss_StandardGpuResources_setPinnedMemory(gpuResource, C.size_t(defaultGPUPinnedMemory)); code != 0 {
 		C.faiss_StandardGpuResources_free(gpuResource)
-		return nil, NewError(ErrGPUOperationFailed, int(code))
+		return nil, NewError(ErrGPUCloneFailed, int(code))
 	}
 
 	var clonerOpts *C.FaissGpuClonerOptions
 	if code := C.faiss_GpuClonerOptions_new(&clonerOpts); code != 0 {
 		C.faiss_StandardGpuResources_free(gpuResource)
-		return nil, NewError(ErrGPUOperationFailed, int(code))
+		return nil, NewError(ErrGPUCloneFailed, int(code))
 	}
 	defer C.faiss_GpuClonerOptions_free(clonerOpts)
 

--- a/gpu.go
+++ b/gpu.go
@@ -82,7 +82,7 @@ func numGPUs() (int, error) {
 	var rv C.int
 	c := C.faiss_get_num_gpus(&rv)
 	if c != 0 {
-		return 0, NewError(ErrGPUSetupFailed, int(c))
+		return 0, newFaissError(ErrGPUSetupFailed, getLastError(), int(c))
 	}
 	return int(rv), nil
 }
@@ -242,7 +242,7 @@ func CloneToGPU(cpuIndex *IndexImpl) (*GPUIndexImpl, error) {
 
 	var gpuResource *C.FaissStandardGpuResources
 	if code := C.faiss_StandardGpuResources_new(&gpuResource); code != 0 {
-		return nil, NewError(ErrGPUCloneFailed, int(code))
+		return nil, newFaissError(ErrGPUCloneFailed, getLastError(), int(code))
 	}
 
 	// Disable the pre-allocated temp memory pool so that all GPU memory is
@@ -250,17 +250,17 @@ func CloneToGPU(cpuIndex *IndexImpl) (*GPUIndexImpl, error) {
 	// allocations via cudaMalloc/cudaFree on demand.
 	if code := C.faiss_StandardGpuResources_noTempMemory(gpuResource); code != 0 {
 		C.faiss_StandardGpuResources_free(gpuResource)
-		return nil, NewError(ErrGPUCloneFailed, int(code))
+		return nil, newFaissError(ErrGPUCloneFailed, getLastError(), int(code))
 	}
 	if code := C.faiss_StandardGpuResources_setPinnedMemory(gpuResource, C.size_t(defaultGPUPinnedMemory)); code != 0 {
 		C.faiss_StandardGpuResources_free(gpuResource)
-		return nil, NewError(ErrGPUCloneFailed, int(code))
+		return nil, newFaissError(ErrGPUCloneFailed, getLastError(), int(code))
 	}
 
 	var clonerOpts *C.FaissGpuClonerOptions
 	if code := C.faiss_GpuClonerOptions_new(&clonerOpts); code != 0 {
 		C.faiss_StandardGpuResources_free(gpuResource)
-		return nil, NewError(ErrGPUCloneFailed, int(code))
+		return nil, newFaissError(ErrGPUCloneFailed, getLastError(), int(code))
 	}
 	defer C.faiss_GpuClonerOptions_free(clonerOpts)
 
@@ -276,7 +276,7 @@ func CloneToGPU(cpuIndex *IndexImpl) (*GPUIndexImpl, error) {
 	)
 	if code != 0 {
 		C.faiss_StandardGpuResources_free(gpuResource)
-		return nil, NewError(ErrGPUCloneFailed, int(code))
+		return nil, newFaissError(ErrGPUCloneFailed, getLastError(), int(code))
 	}
 
 	idx := &faissIndex{
@@ -300,7 +300,7 @@ func CloneToCPU(gpuIndex *GPUIndexImpl) (*IndexImpl, error) {
 		&cpuIdx,
 	)
 	if code != 0 {
-		return nil, NewError(ErrGPUCloneFailed, int(code))
+		return nil, newFaissError(ErrGPUCloneFailed, getLastError(), int(code))
 	}
 	return &IndexImpl{&faissIndex{idx: cpuIdx}}, nil
 }

--- a/gpu.go
+++ b/gpu.go
@@ -82,7 +82,7 @@ func numGPUs() (int, error) {
 	var rv C.int
 	c := C.faiss_get_num_gpus(&rv)
 	if c != 0 {
-		return 0, NewError(ErrGPUOperationFailed, int(c))
+		return 0, NewError(ErrGPUSetupFailed, int(c))
 	}
 	return int(rv), nil
 }
@@ -177,7 +177,7 @@ func (lb *gpuLoadBalancer) nextDevice() (int, error) {
 	devices := lb.sortedDevices
 	n := len(devices)
 	if n == 0 {
-		return 0, ErrNoGPUDevices
+		return 0, ErrNoUsableGPUDevices
 	}
 
 	// atomically allocates the GPU. Minus 1 for zero based index
@@ -187,7 +187,7 @@ func (lb *gpuLoadBalancer) nextDevice() (int, error) {
 
 func getBestGPUDevice() (int, error) {
 	if gpuCount == 0 || loadBalancer == nil {
-		return 0, ErrNoGPUDevices
+		return 0, ErrNoUsableGPUDevices
 	}
 	return loadBalancer.nextDevice()
 }

--- a/gpu.go
+++ b/gpu.go
@@ -26,8 +26,6 @@ package faiss
 */
 import "C"
 import (
-	"errors"
-	"fmt"
 	"math/rand"
 	"reflect"
 	"sort"
@@ -35,12 +33,6 @@ import (
 	"sync/atomic"
 	"time"
 	"unsafe"
-)
-
-var (
-	errAccessingGPUDevices = errors.New("error accessing GPU devices")
-	errNilIndex            = errors.New("index is nil")
-	errNoGPUDevices        = errors.New("no GPU devices available")
 )
 
 // memorySpace controls where GPU index data is allocated.
@@ -90,7 +82,7 @@ func numGPUs() (int, error) {
 	var rv C.int
 	c := C.faiss_get_num_gpus(&rv)
 	if c != 0 {
-		return 0, fmt.Errorf("error getting number of GPUs, err: %v", getLastError())
+		return 0, NewError(ErrGPUOperationFailed, int(c))
 	}
 	return int(rv), nil
 }
@@ -185,7 +177,7 @@ func (lb *gpuLoadBalancer) nextDevice() (int, error) {
 	devices := lb.sortedDevices
 	n := len(devices)
 	if n == 0 {
-		return 0, errAccessingGPUDevices
+		return 0, ErrNoGPUDevices
 	}
 
 	// atomically allocates the GPU. Minus 1 for zero based index
@@ -195,7 +187,7 @@ func (lb *gpuLoadBalancer) nextDevice() (int, error) {
 
 func getBestGPUDevice() (int, error) {
 	if gpuCount == 0 || loadBalancer == nil {
-		return 0, errNoGPUDevices
+		return 0, ErrNoGPUDevices
 	}
 	return loadBalancer.nextDevice()
 }
@@ -239,7 +231,7 @@ func (g *GPUIndexImpl) Size() uint64 {
 // CloneToGPU transfers a CPU index to the best available GPU based on free memory.
 func CloneToGPU(cpuIndex *IndexImpl) (*GPUIndexImpl, error) {
 	if cpuIndex == nil {
-		return nil, errNilIndex
+		return nil, ErrIndexNil
 	}
 
 	// Use the load balancer to select the best GPU device
@@ -250,7 +242,7 @@ func CloneToGPU(cpuIndex *IndexImpl) (*GPUIndexImpl, error) {
 
 	var gpuResource *C.FaissStandardGpuResources
 	if code := C.faiss_StandardGpuResources_new(&gpuResource); code != 0 {
-		return nil, fmt.Errorf("failed to initialize GPU resources: error code %d, err: %v", code, getLastError())
+		return nil, NewError(ErrGPUOperationFailed, int(code))
 	}
 
 	// Disable the pre-allocated temp memory pool so that all GPU memory is
@@ -258,17 +250,17 @@ func CloneToGPU(cpuIndex *IndexImpl) (*GPUIndexImpl, error) {
 	// allocations via cudaMalloc/cudaFree on demand.
 	if code := C.faiss_StandardGpuResources_noTempMemory(gpuResource); code != 0 {
 		C.faiss_StandardGpuResources_free(gpuResource)
-		return nil, fmt.Errorf("failed to disable GPU temp memory: error code %d, err: %v", code, getLastError())
+		return nil, NewError(ErrGPUOperationFailed, int(code))
 	}
 	if code := C.faiss_StandardGpuResources_setPinnedMemory(gpuResource, C.size_t(defaultGPUPinnedMemory)); code != 0 {
 		C.faiss_StandardGpuResources_free(gpuResource)
-		return nil, fmt.Errorf("failed to disable GPU pinned memory: error code %d, err: %v", code, getLastError())
+		return nil, NewError(ErrGPUOperationFailed, int(code))
 	}
 
 	var clonerOpts *C.FaissGpuClonerOptions
 	if code := C.faiss_GpuClonerOptions_new(&clonerOpts); code != 0 {
 		C.faiss_StandardGpuResources_free(gpuResource)
-		return nil, fmt.Errorf("failed to create cloner options: error code %d, err: %v", code, getLastError())
+		return nil, NewError(ErrGPUOperationFailed, int(code))
 	}
 	defer C.faiss_GpuClonerOptions_free(clonerOpts)
 
@@ -284,7 +276,7 @@ func CloneToGPU(cpuIndex *IndexImpl) (*GPUIndexImpl, error) {
 	)
 	if code != 0 {
 		C.faiss_StandardGpuResources_free(gpuResource)
-		return nil, fmt.Errorf("failed to transfer index to GPU device %d: error code %d, err: %v", device, code, getLastError())
+		return nil, NewError(ErrGPUCloneFailed, int(code))
 	}
 
 	idx := &faissIndex{
@@ -299,7 +291,7 @@ func CloneToGPU(cpuIndex *IndexImpl) (*GPUIndexImpl, error) {
 
 func CloneToCPU(gpuIndex *GPUIndexImpl) (*IndexImpl, error) {
 	if gpuIndex == nil {
-		return nil, errNilIndex
+		return nil, ErrIndexNil
 	}
 
 	var cpuIdx *C.FaissIndex
@@ -308,7 +300,7 @@ func CloneToCPU(gpuIndex *GPUIndexImpl) (*IndexImpl, error) {
 		&cpuIdx,
 	)
 	if code != 0 {
-		return nil, fmt.Errorf("failed to transfer index to CPU: %v", getLastError())
+		return nil, NewError(ErrGPUCloneFailed, int(code))
 	}
 	return &IndexImpl{&faissIndex{idx: cpuIdx}}, nil
 }

--- a/gpu_stub.go
+++ b/gpu_stub.go
@@ -17,27 +17,23 @@
 
 package faiss
 
-import "errors"
-
 // GPUIndexImpl is an opaque type when not built with GPU support.
 type GPUIndexImpl struct{}
 
-func (g *GPUIndexImpl) Train(x []float32) error { return errGPUNotBuilt }
-func (g *GPUIndexImpl) Add(x []float32) error   { return errGPUNotBuilt }
+func (g *GPUIndexImpl) Train(x []float32) error { return ErrNoGPUDevices }
+func (g *GPUIndexImpl) Add(x []float32) error   { return ErrNoGPUDevices }
 func (g *GPUIndexImpl) Search(x []float32, k int64) ([]float32, []int64, error) {
-	return nil, nil, errGPUNotBuilt
+	return nil, nil, ErrNoGPUDevices
 }
 func (g *GPUIndexImpl) Close()       {}
 func (g *GPUIndexImpl) Size() uint64 { return 0 }
 
-var errGPUNotBuilt = errors.New("not built with GPU support (requires -tags gpu)")
-
 // CloneToGPU is not available without the gpu build tag.
 func CloneToGPU(_ *IndexImpl) (*GPUIndexImpl, error) {
-	return nil, errGPUNotBuilt
+	return nil, ErrNoGPUDevices
 }
 
 // CloneToCPU is not available without the gpu build tag.
 func CloneToCPU(_ *GPUIndexImpl) (*IndexImpl, error) {
-	return nil, errGPUNotBuilt
+	return nil, ErrNoGPUDevices
 }

--- a/gpu_stub.go
+++ b/gpu_stub.go
@@ -20,20 +20,20 @@ package faiss
 // GPUIndexImpl is an opaque type when not built with GPU support.
 type GPUIndexImpl struct{}
 
-func (g *GPUIndexImpl) Train(x []float32) error { return ErrNoGPUDevices }
-func (g *GPUIndexImpl) Add(x []float32) error   { return ErrNoGPUDevices }
+func (g *GPUIndexImpl) Train(x []float32) error { return ErrNoUsableGPUDevices }
+func (g *GPUIndexImpl) Add(x []float32) error   { return ErrNoUsableGPUDevices }
 func (g *GPUIndexImpl) Search(x []float32, k int64) ([]float32, []int64, error) {
-	return nil, nil, ErrNoGPUDevices
+	return nil, nil, ErrNoUsableGPUDevices
 }
 func (g *GPUIndexImpl) Close()       {}
 func (g *GPUIndexImpl) Size() uint64 { return 0 }
 
 // CloneToGPU is not available without the gpu build tag.
 func CloneToGPU(_ *IndexImpl) (*GPUIndexImpl, error) {
-	return nil, ErrNoGPUDevices
+	return nil, ErrNoUsableGPUDevices
 }
 
 // CloneToCPU is not available without the gpu build tag.
 func CloneToCPU(_ *GPUIndexImpl) (*IndexImpl, error) {
-	return nil, ErrNoGPUDevices
+	return nil, ErrNoUsableGPUDevices
 }

--- a/index.go
+++ b/index.go
@@ -138,6 +138,9 @@ type Index interface {
 	// set the quantizers from a source index into this index, applicable only
 	// for IVF indexes
 	SetQuantizers(source Index) error
+
+	// CodeSize returns the size of the produced codes in bytes.
+	CodeSize() (int, error)
 }
 
 type faissIndex struct {
@@ -159,6 +162,14 @@ func (idx *faissIndex) Size() uint64 {
 
 func (idx *faissIndex) D() int {
 	return int(C.faiss_Index_d(idx.idx))
+}
+
+func (idx *faissIndex) CodeSize() (int, error) {
+	var size C.size_t
+	if c := C.faiss_Index_sa_code_size(idx.idx, &size); c != 0 {
+		return 0, getLastError()
+	}
+	return int(size), nil
 }
 
 func (idx *faissIndex) IsTrained() bool {

--- a/index.go
+++ b/index.go
@@ -166,7 +166,7 @@ func (idx *faissIndex) D() int {
 func (idx *faissIndex) CodeSize() (uint64, error) {
 	var size C.size_t
 	if c := C.faiss_Index_sa_code_size(idx.idx, &size); c != 0 {
-		return 0, NewError(ErrInspectIndexFailed, int(c))
+		return 0, newFaissError(ErrInspectIndexFailed, getLastError(), int(c))
 	}
 	return uint64(size), nil
 }
@@ -186,7 +186,7 @@ func (idx *faissIndex) MetricType() int {
 func (idx *faissIndex) Train(x []float32) error {
 	n := len(x) / idx.D()
 	if c := C.faiss_Index_train(idx.idx, C.idx_t(n), (*C.float)(&x[0])); c != 0 {
-		return NewError(ErrTrainFailed, int(c))
+		return newFaissError(ErrTrainFailed, getLastError(), int(c))
 	}
 	return nil
 }
@@ -194,7 +194,7 @@ func (idx *faissIndex) Train(x []float32) error {
 func (idx *faissIndex) Add(x []float32) error {
 	n := len(x) / idx.D()
 	if c := C.faiss_Index_add(idx.idx, C.idx_t(n), (*C.float)(&x[0])); c != 0 {
-		return NewError(ErrAddFailed, int(c))
+		return newFaissError(ErrAddFailed, getLastError(), int(c))
 	}
 	return nil
 }
@@ -224,7 +224,7 @@ func (idx *faissIndex) ObtainClusterVectorCountsFromIVFIndex(includedVectors Sel
 		C.size_t(nlist),
 		params.sp,
 	); c != 0 {
-		return nil, NewError(ErrInspectIndexFailed, int(c))
+		return nil, newFaissError(ErrInspectIndexFailed, getLastError(), int(c))
 	}
 	return listCount, nil
 }
@@ -268,7 +268,7 @@ func (idx *faissIndex) ObtainClustersWithDistancesFromIVFIndex(x []float32, incl
 		(*C.idx_t)(&centroids[0]),
 		params.sp,
 	); c != 0 {
-		return nil, nil, NewError(ErrSearchFailed, int(c))
+		return nil, nil, newFaissError(ErrSearchFailed, getLastError(), int(c))
 	}
 
 	return centroids, centroidDistances, nil
@@ -299,7 +299,7 @@ func (idx *faissIndex) ObtainKCentroidCardinalitiesFromIVFIndex(limit int, desce
 		nil,
 	)
 	if c != 0 {
-		return nil, nil, NewError(ErrInspectIndexFailed, int(c))
+		return nil, nil, newFaissError(ErrInspectIndexFailed, getLastError(), int(c))
 	}
 
 	topIndices := getIndicesOfKCentroidCardinalities(
@@ -401,7 +401,7 @@ func (idx *faissIndex) SearchClustersFromIVFIndex(eligibleCentroidIDs []int64, c
 		(C.int)(0),
 		searchParams.sp,
 	); c != 0 {
-		return nil, nil, NewError(ErrSearchFailed, int(c))
+		return nil, nil, newFaissError(ErrSearchFailed, getLastError(), int(c))
 	}
 
 	return distances, labels, nil
@@ -415,7 +415,7 @@ func (idx *faissIndex) AddWithIDs(x []float32, xids []int64) error {
 		(*C.float)(&x[0]),
 		(*C.idx_t)(&xids[0]),
 	); c != 0 {
-		return NewError(ErrAddFailed, int(c))
+		return newFaissError(ErrAddFailed, getLastError(), int(c))
 	}
 	return nil
 }
@@ -437,7 +437,7 @@ func (idx *faissIndex) Search(x []float32, k int64) (
 		(*C.float)(&distances[0]),
 		(*C.idx_t)(&labels[0]),
 	); c != 0 {
-		err = NewError(ErrSearchFailed, int(c))
+		err = newFaissError(ErrSearchFailed, getLastError(), int(c))
 	}
 
 	return
@@ -457,7 +457,7 @@ func (idx *faissIndex) Reconstruct(key int64) (recons []float32, err error) {
 		C.idx_t(key),
 		(*C.float)(&rv[0]),
 	); c != 0 {
-		err = NewError(ErrReconstructFailed, int(c))
+		err = newFaissError(ErrReconstructFailed, getLastError(), int(c))
 	}
 
 	return rv, err
@@ -472,7 +472,7 @@ func (idx *faissIndex) ReconstructBatch(keys []int64, recons []float32) ([]float
 		(*C.idx_t)(&keys[0]),
 		(*C.float)(&recons[0]),
 	); c != 0 {
-		err = NewError(ErrReconstructFailed, int(c))
+		err = newFaissError(ErrReconstructFailed, getLastError(), int(c))
 	}
 
 	return recons, err
@@ -491,7 +491,7 @@ func (idx *faissIndex) MergeFrom(other Index, add_id int64) (err error) {
 		other.cPtr(),
 		(C.idx_t)(add_id),
 	); c != 0 {
-		err = NewError(ErrMergeFromFailed, int(c))
+		err = newFaissError(ErrMergeFromFailed, getLastError(), int(c))
 	}
 
 	return err
@@ -503,7 +503,7 @@ func (idx *faissIndex) RangeSearch(x []float32, radius float32) (
 	n := len(x) / idx.D()
 	var rsr *C.FaissRangeSearchResult
 	if c := C.faiss_RangeSearchResult_new(&rsr, C.idx_t(n)); c != 0 {
-		return nil, NewError(ErrSearchFailed, int(c))
+		return nil, newFaissError(ErrSearchFailed, getLastError(), int(c))
 	}
 	if c := C.faiss_Index_range_search(
 		idx.idx,
@@ -512,7 +512,7 @@ func (idx *faissIndex) RangeSearch(x []float32, radius float32) (
 		C.float(radius),
 		rsr,
 	); c != 0 {
-		return nil, NewError(ErrSearchFailed, int(c))
+		return nil, newFaissError(ErrSearchFailed, getLastError(), int(c))
 	}
 	return &RangeSearchResult{rsr}, nil
 }
@@ -521,7 +521,7 @@ func (idx *faissIndex) DistCompute(queryData []float32, ids []int64) ([]float32,
 	distances := make([]float32, len(ids))
 	if c := C.faiss_Index_dist_compute(idx.idx, (*C.float)(&queryData[0]),
 		(*C.idx_t)(&ids[0]), (C.size_t)(len(ids)), (*C.float)(&distances[0])); c != 0 {
-		return nil, NewError(ErrSearchFailed, int(c))
+		return nil, newFaissError(ErrSearchFailed, getLastError(), int(c))
 	}
 
 	return distances, nil
@@ -529,7 +529,7 @@ func (idx *faissIndex) DistCompute(queryData []float32, ids []int64) ([]float32,
 
 func (idx *faissIndex) Reset() error {
 	if c := C.faiss_Index_reset(idx.idx); c != 0 {
-		return NewError(ErrResetIndexFailed, int(c))
+		return newFaissError(ErrResetIndexFailed, getLastError(), int(c))
 	}
 	return nil
 }
@@ -537,7 +537,7 @@ func (idx *faissIndex) Reset() error {
 func (idx *faissIndex) RemoveIDs(sel *IDSelector) (int, error) {
 	var nRemoved C.size_t
 	if c := C.faiss_Index_remove_ids(idx.idx, sel.sel, &nRemoved); c != 0 {
-		return 0, NewError(ErrRemoveIDsFailed, int(c))
+		return 0, newFaissError(ErrRemoveIDsFailed, getLastError(), int(c))
 	}
 	return int(nRemoved), nil
 }
@@ -567,7 +567,7 @@ func (idx *faissIndex) searchWithOptions(x []float32, k int64, sel Selector, par
 		(*C.float)(&distances[0]),
 		(*C.idx_t)(&labels[0]),
 	); c != 0 {
-		return nil, nil, NewError(ErrSearchFailed, int(c))
+		return nil, nil, newFaissError(ErrSearchFailed, getLastError(), int(c))
 	}
 	return distances, labels, nil
 }
@@ -624,7 +624,7 @@ func IndexFactory(d int, description string, metric int) (*IndexImpl, error) {
 	var idx faissIndex
 	c := C.faiss_index_factory(&idx.idx, C.int(d), cdesc, C.FaissMetricType(metric))
 	if c != 0 {
-		return nil, NewError(ErrCreateIndexFailed, int(c))
+		return nil, newFaissError(ErrCreateIndexFailed, getLastError(), int(c))
 	}
 	return &IndexImpl{&idx}, nil
 }

--- a/index.go
+++ b/index.go
@@ -13,7 +13,6 @@ package faiss
 import "C"
 import (
 	"encoding/json"
-	"fmt"
 	"reflect"
 	"sort"
 	"unsafe"
@@ -167,7 +166,7 @@ func (idx *faissIndex) D() int {
 func (idx *faissIndex) CodeSize() (uint64, error) {
 	var size C.size_t
 	if c := C.faiss_Index_sa_code_size(idx.idx, &size); c != 0 {
-		return 0, getLastError()
+		return 0, NewError(ErrInspectIndexFailed, int(c))
 	}
 	return uint64(size), nil
 }
@@ -187,7 +186,7 @@ func (idx *faissIndex) MetricType() int {
 func (idx *faissIndex) Train(x []float32) error {
 	n := len(x) / idx.D()
 	if c := C.faiss_Index_train(idx.idx, C.idx_t(n), (*C.float)(&x[0])); c != 0 {
-		return getLastError()
+		return NewError(ErrTrainIndexFailed, int(c))
 	}
 	return nil
 }
@@ -195,7 +194,7 @@ func (idx *faissIndex) Train(x []float32) error {
 func (idx *faissIndex) Add(x []float32) error {
 	n := len(x) / idx.D()
 	if c := C.faiss_Index_add(idx.idx, C.idx_t(n), (*C.float)(&x[0])); c != 0 {
-		return getLastError()
+		return NewError(ErrAddFailed, int(c))
 	}
 	return nil
 }
@@ -204,7 +203,7 @@ func (idx *faissIndex) ObtainClusterVectorCountsFromIVFIndex(includedVectors Sel
 	// Applicable only to IVF indexes
 	ivfPtr := C.faiss_IndexIVF_cast(idx.cPtr())
 	if ivfPtr == nil {
-		return nil, errNotIVFIndex
+		return nil, ErrNotIVFIndex
 	}
 	// Creating a slice to hold the count of vectors per cluster
 	// Since we have nlist clusters, we create a slice of size nlist
@@ -225,7 +224,7 @@ func (idx *faissIndex) ObtainClusterVectorCountsFromIVFIndex(includedVectors Sel
 		C.size_t(nlist),
 		params.sp,
 	); c != 0 {
-		return nil, getLastError()
+		return nil, NewError(ErrInspectIndexFailed, int(c))
 	}
 	return listCount, nil
 }
@@ -246,7 +245,7 @@ func (idx *faissIndex) ObtainClustersWithDistancesFromIVFIndex(x []float32, incl
 	// Applicable only to IVF indexes
 	ivfPtr := C.faiss_IndexIVF_cast(idx.cPtr())
 	if ivfPtr == nil {
-		return nil, nil, errNotIVFIndex
+		return nil, nil, ErrNotIVFIndex
 	}
 	params, err := NewStandardSearchParams(includedCentroids)
 	if err != nil {
@@ -269,7 +268,7 @@ func (idx *faissIndex) ObtainClustersWithDistancesFromIVFIndex(x []float32, incl
 		(*C.idx_t)(&centroids[0]),
 		params.sp,
 	); c != 0 {
-		return nil, nil, getLastError()
+		return nil, nil, NewError(ErrSearchFailed, int(c))
 	}
 
 	return centroids, centroidDistances, nil
@@ -300,7 +299,7 @@ func (idx *faissIndex) ObtainKCentroidCardinalitiesFromIVFIndex(limit int, desce
 		nil,
 	)
 	if c != 0 {
-		return nil, nil, getLastError()
+		return nil, nil, NewError(ErrInspectIndexFailed, int(c))
 	}
 
 	topIndices := getIndicesOfKCentroidCardinalities(
@@ -353,12 +352,12 @@ func (idx *faissIndex) SearchClustersFromIVFIndex(eligibleCentroidIDs []int64, c
 	// Applicable only to IVF indexes
 	ivfPtr := C.faiss_IndexIVF_cast(idx.cPtr())
 	if ivfPtr == nil {
-		return nil, nil, errNotIVFIndex
+		return nil, nil, ErrNotIVFIndex
 	}
 	// If no include selector is provided, we have no results to return.
 	// return an error indicating that the SearchClustersFromIVFIndex requires a valid selector.
 	if include == nil {
-		return nil, nil, fmt.Errorf("SearchClustersFromIVFIndex requires a valid include selector")
+		return nil, nil, ErrSelectorNil
 	}
 	// create a temporary search params object to set nprobe, this will override
 	// the nprobe and the nlist set at index time, this will allow the search to
@@ -402,7 +401,7 @@ func (idx *faissIndex) SearchClustersFromIVFIndex(eligibleCentroidIDs []int64, c
 		(C.int)(0),
 		searchParams.sp,
 	); c != 0 {
-		return nil, nil, getLastError()
+		return nil, nil, NewError(ErrSearchFailed, int(c))
 	}
 
 	return distances, labels, nil
@@ -416,7 +415,7 @@ func (idx *faissIndex) AddWithIDs(x []float32, xids []int64) error {
 		(*C.float)(&x[0]),
 		(*C.idx_t)(&xids[0]),
 	); c != 0 {
-		return getLastError()
+		return NewError(ErrAddFailed, int(c))
 	}
 	return nil
 }
@@ -438,7 +437,7 @@ func (idx *faissIndex) Search(x []float32, k int64) (
 		(*C.float)(&distances[0]),
 		(*C.idx_t)(&labels[0]),
 	); c != 0 {
-		err = getLastError()
+		err = NewError(ErrSearchFailed, int(c))
 	}
 
 	return
@@ -458,7 +457,7 @@ func (idx *faissIndex) Reconstruct(key int64) (recons []float32, err error) {
 		C.idx_t(key),
 		(*C.float)(&rv[0]),
 	); c != 0 {
-		err = getLastError()
+		err = NewError(ErrReconstructFailed, int(c))
 	}
 
 	return rv, err
@@ -473,7 +472,7 @@ func (idx *faissIndex) ReconstructBatch(keys []int64, recons []float32) ([]float
 		(*C.idx_t)(&keys[0]),
 		(*C.float)(&recons[0]),
 	); c != 0 {
-		err = getLastError()
+		err = NewError(ErrReconstructFailed, int(c))
 	}
 
 	return recons, err
@@ -484,7 +483,7 @@ func (idx *faissIndex) MergeFrom(other Index, add_id int64) (err error) {
 	// todo: support on Flat index as well
 	if !(idx.IsIVFIndex() && other.IsIVFIndex()) &&
 		!(idx.IsSQIndex() && other.IsSQIndex()) {
-		return fmt.Errorf("faissIndex MergeFrom err: %w", errMergeFromNotSupported)
+		return ErrMergeFromNotSupported
 	}
 
 	if c := C.faiss_Index_merge_from(
@@ -492,7 +491,7 @@ func (idx *faissIndex) MergeFrom(other Index, add_id int64) (err error) {
 		other.cPtr(),
 		(C.idx_t)(add_id),
 	); c != 0 {
-		err = getLastError()
+		err = NewError(ErrMergeFromFailed, int(c))
 	}
 
 	return err
@@ -504,7 +503,7 @@ func (idx *faissIndex) RangeSearch(x []float32, radius float32) (
 	n := len(x) / idx.D()
 	var rsr *C.FaissRangeSearchResult
 	if c := C.faiss_RangeSearchResult_new(&rsr, C.idx_t(n)); c != 0 {
-		return nil, getLastError()
+		return nil, NewError(ErrSearchFailed, int(c))
 	}
 	if c := C.faiss_Index_range_search(
 		idx.idx,
@@ -513,7 +512,7 @@ func (idx *faissIndex) RangeSearch(x []float32, radius float32) (
 		C.float(radius),
 		rsr,
 	); c != 0 {
-		return nil, getLastError()
+		return nil, NewError(ErrSearchFailed, int(c))
 	}
 	return &RangeSearchResult{rsr}, nil
 }
@@ -522,7 +521,7 @@ func (idx *faissIndex) DistCompute(queryData []float32, ids []int64) ([]float32,
 	distances := make([]float32, len(ids))
 	if c := C.faiss_Index_dist_compute(idx.idx, (*C.float)(&queryData[0]),
 		(*C.idx_t)(&ids[0]), (C.size_t)(len(ids)), (*C.float)(&distances[0])); c != 0 {
-		return nil, getLastError()
+		return nil, NewError(ErrSearchFailed, int(c))
 	}
 
 	return distances, nil
@@ -530,7 +529,7 @@ func (idx *faissIndex) DistCompute(queryData []float32, ids []int64) ([]float32,
 
 func (idx *faissIndex) Reset() error {
 	if c := C.faiss_Index_reset(idx.idx); c != 0 {
-		return getLastError()
+		return NewError(ErrResetIndexFailed, int(c))
 	}
 	return nil
 }
@@ -538,7 +537,7 @@ func (idx *faissIndex) Reset() error {
 func (idx *faissIndex) RemoveIDs(sel *IDSelector) (int, error) {
 	var nRemoved C.size_t
 	if c := C.faiss_Index_remove_ids(idx.idx, sel.sel, &nRemoved); c != 0 {
-		return 0, getLastError()
+		return 0, NewError(ErrRemoveIDsFailed, int(c))
 	}
 	return int(nRemoved), nil
 }
@@ -568,7 +567,7 @@ func (idx *faissIndex) searchWithOptions(x []float32, k int64, sel Selector, par
 		(*C.float)(&distances[0]),
 		(*C.idx_t)(&labels[0]),
 	); c != 0 {
-		return nil, nil, getLastError()
+		return nil, nil, NewError(ErrSearchFailed, int(c))
 	}
 	return distances, labels, nil
 }
@@ -625,7 +624,7 @@ func IndexFactory(d int, description string, metric int) (*IndexImpl, error) {
 	var idx faissIndex
 	c := C.faiss_index_factory(&idx.idx, C.int(d), cdesc, C.FaissMetricType(metric))
 	if c != 0 {
-		return nil, getLastError()
+		return nil, NewError(ErrCreateIndexFailed, int(c))
 	}
 	return &IndexImpl{&idx}, nil
 }

--- a/index.go
+++ b/index.go
@@ -140,7 +140,7 @@ type Index interface {
 	SetQuantizers(source Index) error
 
 	// CodeSize returns the size of the produced codes in bytes.
-	CodeSize() (int, error)
+	CodeSize() (uint64, error)
 }
 
 type faissIndex struct {
@@ -164,12 +164,12 @@ func (idx *faissIndex) D() int {
 	return int(C.faiss_Index_d(idx.idx))
 }
 
-func (idx *faissIndex) CodeSize() (int, error) {
+func (idx *faissIndex) CodeSize() (uint64, error) {
 	var size C.size_t
 	if c := C.faiss_Index_sa_code_size(idx.idx, &size); c != 0 {
 		return 0, getLastError()
 	}
-	return int(size), nil
+	return uint64(size), nil
 }
 
 func (idx *faissIndex) IsTrained() bool {

--- a/index.go
+++ b/index.go
@@ -186,7 +186,7 @@ func (idx *faissIndex) MetricType() int {
 func (idx *faissIndex) Train(x []float32) error {
 	n := len(x) / idx.D()
 	if c := C.faiss_Index_train(idx.idx, C.idx_t(n), (*C.float)(&x[0])); c != 0 {
-		return NewError(ErrTrainIndexFailed, int(c))
+		return NewError(ErrTrainFailed, int(c))
 	}
 	return nil
 }

--- a/index_binary.go
+++ b/index_binary.go
@@ -173,7 +173,7 @@ func (b *faissBinaryIndex) Train(x []uint8) error {
 	n := (len(x) * 8) / b.D()
 	if c := C.faiss_IndexBinary_train(b.bIdx, C.idx_t(n),
 		(*C.uint8_t)(&x[0])); c != 0 {
-		return NewError(ErrTrainIndexFailed, int(c))
+		return NewError(ErrTrainFailed, int(c))
 	}
 	return nil
 }

--- a/index_binary.go
+++ b/index_binary.go
@@ -12,7 +12,6 @@ package faiss
 import "C"
 import (
 	"encoding/json"
-	"fmt"
 	"reflect"
 	"unsafe"
 )
@@ -134,13 +133,13 @@ func (b *faissBinaryIndex) SetDirectMap(mapType int) (err error) {
 	// Applicable only to IVF indexes
 	ivfPtrBinary := C.faiss_IndexBinaryIVF_cast(b.bIdx)
 	if ivfPtrBinary == nil {
-		return errNotBIVFIndex
+		return ErrNotBIVFIndex
 	}
 	if c := C.faiss_IndexBinaryIVF_set_direct_map(
 		ivfPtrBinary,
 		C.int(mapType),
 	); c != 0 {
-		err = getLastError()
+		err = NewError(ErrSetParamsFailed, int(c))
 	}
 	return err
 }
@@ -174,7 +173,7 @@ func (b *faissBinaryIndex) Train(x []uint8) error {
 	n := (len(x) * 8) / b.D()
 	if c := C.faiss_IndexBinary_train(b.bIdx, C.idx_t(n),
 		(*C.uint8_t)(&x[0])); c != 0 {
-		return getLastError()
+		return NewError(ErrTrainIndexFailed, int(c))
 	}
 	return nil
 }
@@ -183,7 +182,7 @@ func (b *faissBinaryIndex) Add(x []uint8) error {
 	n := (len(x) * 8) / b.D()
 	if c := C.faiss_IndexBinary_add(b.bIdx, C.idx_t(n),
 		(*C.uint8_t)(&x[0])); c != 0 {
-		return getLastError()
+		return NewError(ErrAddFailed, int(c))
 	}
 	return nil
 }
@@ -202,7 +201,7 @@ func (b *faissBinaryIndex) Search(xb []uint8, k int64) (
 		(*C.int32_t)(&distances[0]),
 		(*C.idx_t)(&labels[0]),
 	); c != 0 {
-		return nil, nil, getLastError()
+		return nil, nil, NewError(ErrSearchFailed, int(c))
 	}
 	return distances, labels, nil
 }
@@ -236,7 +235,7 @@ func (b *faissBinaryIndex) searchWithOptions(xb []uint8, k int64, selector Selec
 		(*C.int32_t)(&distances[0]),
 		(*C.idx_t)(&labels[0]),
 	); c != 0 {
-		return nil, nil, getLastError()
+		return nil, nil, NewError(ErrSearchFailed, int(c))
 	}
 	return distances, labels, nil
 }
@@ -245,7 +244,7 @@ func (b *faissBinaryIndex) ObtainClusterVectorCountsFromIVFIndex(includedVectors
 	// Applicable only to IVF indexes
 	ivfPtrBinary := C.faiss_IndexBinaryIVF_cast(b.bIdx)
 	if ivfPtrBinary == nil {
-		return nil, errNotBIVFIndex
+		return nil, ErrNotBIVFIndex
 	}
 	// Creating a slice to hold the count of vectors per cluster
 	// Since we have nlist clusters, we create a slice of size nlist
@@ -266,7 +265,7 @@ func (b *faissBinaryIndex) ObtainClusterVectorCountsFromIVFIndex(includedVectors
 		C.size_t(nlist),
 		params.sp,
 	); c != 0 {
-		return nil, getLastError()
+		return nil, NewError(ErrInspectIndexFailed, int(c))
 	}
 	return listCount, nil
 }
@@ -275,7 +274,7 @@ func (b *faissBinaryIndex) ObtainClustersWithDistancesFromIVFIndex(xb []uint8, i
 	// Applicable only to IVF indexes
 	ivfPtrBinary := C.faiss_IndexBinaryIVF_cast(b.bIdx)
 	if ivfPtrBinary == nil {
-		return nil, nil, errNotBIVFIndex
+		return nil, nil, ErrNotBIVFIndex
 	}
 	params, err := NewStandardSearchParams(includedCentroids)
 	if err != nil {
@@ -298,7 +297,7 @@ func (b *faissBinaryIndex) ObtainClustersWithDistancesFromIVFIndex(xb []uint8, i
 		(*C.idx_t)(&centroids[0]),
 		params.sp,
 	); c != 0 {
-		return nil, nil, getLastError()
+		return nil, nil, NewError(ErrSearchFailed, int(c))
 	}
 
 	return centroids, centroidDistances, nil
@@ -313,7 +312,7 @@ func (b *faissBinaryIndex) ObtainKCentroidCardinalitiesFromIVFIndex(limit int, d
 	// Applicable only to IVF indexes
 	ivfPtrBinary := C.faiss_IndexBinaryIVF_cast(b.bIdx)
 	if ivfPtrBinary == nil {
-		return nil, nil, errNotBIVFIndex
+		return nil, nil, ErrNotBIVFIndex
 	}
 
 	nlist := int(C.faiss_IndexBinaryIVF_nlist(ivfPtrBinary))
@@ -335,7 +334,7 @@ func (b *faissBinaryIndex) ObtainKCentroidCardinalitiesFromIVFIndex(limit int, d
 		nil,
 	)
 	if c != 0 {
-		return nil, nil, getLastError()
+		return nil, nil, NewError(ErrInspectIndexFailed, int(c))
 	}
 
 	topIndices := getIndicesOfKCentroidCardinalities(
@@ -360,12 +359,12 @@ func (b *faissBinaryIndex) SearchClustersFromIVFIndex(eligibleCentroidIDs []int6
 	// Applicable only to IVF indexes
 	ivfPtrBinary := C.faiss_IndexBinaryIVF_cast(b.bIdx)
 	if ivfPtrBinary == nil {
-		return nil, nil, errNotBIVFIndex
+		return nil, nil, ErrNotBIVFIndex
 	}
 	// If no include selector is provided, we have no results to return.
 	// return an error indicating that the SearchClustersFromIVFIndex requires a valid selector.
 	if include == nil {
-		return nil, nil, fmt.Errorf("SearchClustersFromIVFIndex requires a valid include selector")
+		return nil, nil, ErrSelectorNil
 	}
 	// create a temporary search params object to set nprobe, this will override
 	// the nprobe and the nlist set at index time, this will allow the search to
@@ -409,7 +408,7 @@ func (b *faissBinaryIndex) SearchClustersFromIVFIndex(eligibleCentroidIDs []int6
 		(C.int)(0),
 		searchParams.sp,
 	); c != 0 {
-		return nil, nil, getLastError()
+		return nil, nil, NewError(ErrSearchFailed, int(c))
 	}
 
 	return distances, labels, nil
@@ -427,7 +426,7 @@ func (b *faissBinaryIndex) Size() uint64 {
 func (b *faissBinaryIndex) CodeSize() (uint64, error) {
 	var size C.size_t
 	if c := C.faiss_IndexBinary_sa_code_size(b.bIdx, &size); c != 0 {
-		return 0, getLastError()
+		return 0, NewError(ErrInspectIndexFailed, int(c))
 	}
 	return uint64(size), nil
 }
@@ -448,7 +447,7 @@ func BinaryIndexFactory(dims int, description string) (*BinaryIndexImpl, error) 
 	}
 	var idx faissBinaryIndex
 	if c := C.faiss_index_binary_factory(&idx.bIdx, C.int(dims), cDescription); c != 0 {
-		return nil, getLastError()
+		return nil, NewError(ErrCreateIndexFailed, int(c))
 	}
 
 	return &BinaryIndexImpl{&idx}, nil
@@ -457,17 +456,17 @@ func BinaryIndexFactory(dims int, description string) (*BinaryIndexImpl, error) 
 func (idx *faissBinaryIndex) SetQuantizers(srcIndex BinaryIndex) error {
 	bivf := C.faiss_IndexBinaryIVF_cast(idx.bPtr())
 	if bivf == nil {
-		return errNotBIVFIndex
+		return ErrNotBIVFIndex
 	}
 
 	srcIndexPtr := srcIndex.bPtr()
 	if srcIndexPtr == nil {
-		return fmt.Errorf("coarse quantizer is not valid")
+		return ErrSourceIndexNil
 	}
 
-	err := C.faiss_Set_quantizers_binary(idx.bIdx, srcIndexPtr)
-	if err != 0 {
-		return fmt.Errorf("faissBinaryIndex err: %w", errFailedToSetQuantizers)
+	c := C.faiss_Set_quantizers_binary(idx.bIdx, srcIndexPtr)
+	if c != 0 {
+		return NewError(ErrSetParamsFailed, int(c))
 	}
 
 	return nil
@@ -475,7 +474,7 @@ func (idx *faissBinaryIndex) SetQuantizers(srcIndex BinaryIndex) error {
 
 func (idx *faissBinaryIndex) MergeFrom(other BinaryIndex, add_id int64) (err error) {
 	if !idx.IsIVFIndex() && !other.IsIVFIndex() {
-		return fmt.Errorf("faissBinaryIndex err: %w", errNotBIVFIndex)
+		return ErrMergeFromNotSupported
 	}
 
 	if c := C.faiss_IndexBinaryIVF_merge_from(
@@ -483,7 +482,7 @@ func (idx *faissBinaryIndex) MergeFrom(other BinaryIndex, add_id int64) (err err
 		other.bPtr(),
 		(C.idx_t)(add_id),
 	); c != 0 {
-		err = getLastError()
+		err = NewError(ErrMergeFromFailed, int(c))
 	}
 
 	return err

--- a/index_binary.go
+++ b/index_binary.go
@@ -139,7 +139,7 @@ func (b *faissBinaryIndex) SetDirectMap(mapType int) (err error) {
 		ivfPtrBinary,
 		C.int(mapType),
 	); c != 0 {
-		err = NewError(ErrSetParamsFailed, int(c))
+		err = newFaissError(ErrSetParamsFailed, getLastError(), int(c))
 	}
 	return err
 }
@@ -173,7 +173,7 @@ func (b *faissBinaryIndex) Train(x []uint8) error {
 	n := (len(x) * 8) / b.D()
 	if c := C.faiss_IndexBinary_train(b.bIdx, C.idx_t(n),
 		(*C.uint8_t)(&x[0])); c != 0 {
-		return NewError(ErrTrainFailed, int(c))
+		return newFaissError(ErrTrainFailed, getLastError(), int(c))
 	}
 	return nil
 }
@@ -182,7 +182,7 @@ func (b *faissBinaryIndex) Add(x []uint8) error {
 	n := (len(x) * 8) / b.D()
 	if c := C.faiss_IndexBinary_add(b.bIdx, C.idx_t(n),
 		(*C.uint8_t)(&x[0])); c != 0 {
-		return NewError(ErrAddFailed, int(c))
+		return newFaissError(ErrAddFailed, getLastError(), int(c))
 	}
 	return nil
 }
@@ -201,7 +201,7 @@ func (b *faissBinaryIndex) Search(xb []uint8, k int64) (
 		(*C.int32_t)(&distances[0]),
 		(*C.idx_t)(&labels[0]),
 	); c != 0 {
-		return nil, nil, NewError(ErrSearchFailed, int(c))
+		return nil, nil, newFaissError(ErrSearchFailed, getLastError(), int(c))
 	}
 	return distances, labels, nil
 }
@@ -235,7 +235,7 @@ func (b *faissBinaryIndex) searchWithOptions(xb []uint8, k int64, selector Selec
 		(*C.int32_t)(&distances[0]),
 		(*C.idx_t)(&labels[0]),
 	); c != 0 {
-		return nil, nil, NewError(ErrSearchFailed, int(c))
+		return nil, nil, newFaissError(ErrSearchFailed, getLastError(), int(c))
 	}
 	return distances, labels, nil
 }
@@ -265,7 +265,7 @@ func (b *faissBinaryIndex) ObtainClusterVectorCountsFromIVFIndex(includedVectors
 		C.size_t(nlist),
 		params.sp,
 	); c != 0 {
-		return nil, NewError(ErrInspectIndexFailed, int(c))
+		return nil, newFaissError(ErrInspectIndexFailed, getLastError(), int(c))
 	}
 	return listCount, nil
 }
@@ -297,7 +297,7 @@ func (b *faissBinaryIndex) ObtainClustersWithDistancesFromIVFIndex(xb []uint8, i
 		(*C.idx_t)(&centroids[0]),
 		params.sp,
 	); c != 0 {
-		return nil, nil, NewError(ErrSearchFailed, int(c))
+		return nil, nil, newFaissError(ErrSearchFailed, getLastError(), int(c))
 	}
 
 	return centroids, centroidDistances, nil
@@ -334,7 +334,7 @@ func (b *faissBinaryIndex) ObtainKCentroidCardinalitiesFromIVFIndex(limit int, d
 		nil,
 	)
 	if c != 0 {
-		return nil, nil, NewError(ErrInspectIndexFailed, int(c))
+		return nil, nil, newFaissError(ErrInspectIndexFailed, getLastError(), int(c))
 	}
 
 	topIndices := getIndicesOfKCentroidCardinalities(
@@ -408,7 +408,7 @@ func (b *faissBinaryIndex) SearchClustersFromIVFIndex(eligibleCentroidIDs []int6
 		(C.int)(0),
 		searchParams.sp,
 	); c != 0 {
-		return nil, nil, NewError(ErrSearchFailed, int(c))
+		return nil, nil, newFaissError(ErrSearchFailed, getLastError(), int(c))
 	}
 
 	return distances, labels, nil
@@ -426,7 +426,7 @@ func (b *faissBinaryIndex) Size() uint64 {
 func (b *faissBinaryIndex) CodeSize() (uint64, error) {
 	var size C.size_t
 	if c := C.faiss_IndexBinary_sa_code_size(b.bIdx, &size); c != 0 {
-		return 0, NewError(ErrInspectIndexFailed, int(c))
+		return 0, newFaissError(ErrInspectIndexFailed, getLastError(), int(c))
 	}
 	return uint64(size), nil
 }
@@ -447,7 +447,7 @@ func BinaryIndexFactory(dims int, description string) (*BinaryIndexImpl, error) 
 	}
 	var idx faissBinaryIndex
 	if c := C.faiss_index_binary_factory(&idx.bIdx, C.int(dims), cDescription); c != 0 {
-		return nil, NewError(ErrCreateIndexFailed, int(c))
+		return nil, newFaissError(ErrCreateIndexFailed, getLastError(), int(c))
 	}
 	return &BinaryIndexImpl{&idx}, nil
 }
@@ -458,7 +458,7 @@ func (idx *faissBinaryIndex) SetQuantizers(srcIndex BinaryIndex) error {
 	}
 	c := C.faiss_Set_quantizers_binary(idx.bIdx, srcIndex.bPtr())
 	if c != 0 {
-		return NewError(ErrSetQuantizerFailed, int(c))
+		return newFaissError(ErrSetQuantizerFailed, getLastError(), int(c))
 	}
 	return nil
 }
@@ -472,7 +472,7 @@ func (idx *faissBinaryIndex) MergeFrom(other BinaryIndex, add_id int64) (err err
 		other.bPtr(),
 		(C.idx_t)(add_id),
 	); c != 0 {
-		err = NewError(ErrMergeFromFailed, int(c))
+		err = newFaissError(ErrMergeFromFailed, getLastError(), int(c))
 	}
 	return err
 }

--- a/index_binary.go
+++ b/index_binary.go
@@ -449,34 +449,24 @@ func BinaryIndexFactory(dims int, description string) (*BinaryIndexImpl, error) 
 	if c := C.faiss_index_binary_factory(&idx.bIdx, C.int(dims), cDescription); c != 0 {
 		return nil, NewError(ErrCreateIndexFailed, int(c))
 	}
-
 	return &BinaryIndexImpl{&idx}, nil
 }
 
 func (idx *faissBinaryIndex) SetQuantizers(srcIndex BinaryIndex) error {
-	bivf := C.faiss_IndexBinaryIVF_cast(idx.bPtr())
-	if bivf == nil {
-		return ErrNotBIVFIndex
+	if !(idx.IsIVFIndex() && srcIndex.IsIVFIndex()) {
+		return ErrSetQuantizerNotSupported
 	}
-
-	srcIndexPtr := srcIndex.bPtr()
-	if srcIndexPtr == nil {
-		return ErrSourceIndexNil
-	}
-
-	c := C.faiss_Set_quantizers_binary(idx.bIdx, srcIndexPtr)
+	c := C.faiss_Set_quantizers_binary(idx.bIdx, srcIndex.bPtr())
 	if c != 0 {
-		return NewError(ErrSetParamsFailed, int(c))
+		return NewError(ErrSetQuantizerFailed, int(c))
 	}
-
 	return nil
 }
 
 func (idx *faissBinaryIndex) MergeFrom(other BinaryIndex, add_id int64) (err error) {
-	if !idx.IsIVFIndex() && !other.IsIVFIndex() {
+	if !(idx.IsIVFIndex() && other.IsIVFIndex()) {
 		return ErrMergeFromNotSupported
 	}
-
 	if c := C.faiss_IndexBinaryIVF_merge_from(
 		idx.bPtr(),
 		other.bPtr(),
@@ -484,6 +474,5 @@ func (idx *faissBinaryIndex) MergeFrom(other BinaryIndex, add_id int64) (err err
 	); c != 0 {
 		err = NewError(ErrMergeFromFailed, int(c))
 	}
-
 	return err
 }

--- a/index_binary.go
+++ b/index_binary.go
@@ -107,7 +107,7 @@ type BinaryIndex interface {
 	bPtr() *C.FaissIndexBinary
 
 	// CodeSize returns the size of the produced codes in bytes.
-	CodeSize() (int, error)
+	CodeSize() (uint64, error)
 }
 
 type faissBinaryIndex struct {
@@ -424,12 +424,12 @@ func (b *faissBinaryIndex) Size() uint64 {
 	return rv
 }
 
-func (b *faissBinaryIndex) CodeSize() (int, error) {
+func (b *faissBinaryIndex) CodeSize() (uint64, error) {
 	var size C.size_t
 	if c := C.faiss_IndexBinary_code_size(b.bIdx, &size); c != 0 {
 		return 0, getLastError()
 	}
-	return int(size), nil
+	return uint64(size), nil
 }
 
 func (idx *faissBinaryIndex) Close() {

--- a/index_binary.go
+++ b/index_binary.go
@@ -426,7 +426,7 @@ func (b *faissBinaryIndex) Size() uint64 {
 
 func (b *faissBinaryIndex) CodeSize() (uint64, error) {
 	var size C.size_t
-	if c := C.faiss_IndexBinary_code_size(b.bIdx, &size); c != 0 {
+	if c := C.faiss_IndexBinary_sa_code_size(b.bIdx, &size); c != 0 {
 		return 0, getLastError()
 	}
 	return uint64(size), nil

--- a/index_binary.go
+++ b/index_binary.go
@@ -105,6 +105,9 @@ type BinaryIndex interface {
 
 	// bPtr returns a pointer to the underlying C index struct.
 	bPtr() *C.FaissIndexBinary
+
+	// CodeSize returns the size of the produced codes in bytes.
+	CodeSize() (int, error)
 }
 
 type faissBinaryIndex struct {
@@ -419,6 +422,14 @@ func (b *faissBinaryIndex) Size() uint64 {
 		rv += uint64(size)
 	}
 	return rv
+}
+
+func (b *faissBinaryIndex) CodeSize() (int, error) {
+	var size C.size_t
+	if c := C.faiss_IndexBinary_code_size(b.bIdx, &size); c != 0 {
+		return 0, getLastError()
+	}
+	return int(size), nil
 }
 
 func (idx *faissBinaryIndex) Close() {

--- a/index_flat.go
+++ b/index_flat.go
@@ -21,7 +21,7 @@ func NewIndexFlat(d int, metric int) (*IndexFlat, error) {
 		C.idx_t(d),
 		C.FaissMetricType(metric),
 	); c != 0 {
-		return nil, NewError(ErrCreateIndexFailed, int(c))
+		return nil, newFaissError(ErrCreateIndexFailed, getLastError(), int(c))
 	}
 	return &IndexFlat{&idx}, nil
 }

--- a/index_flat.go
+++ b/index_flat.go
@@ -21,7 +21,7 @@ func NewIndexFlat(d int, metric int) (*IndexFlat, error) {
 		C.idx_t(d),
 		C.FaissMetricType(metric),
 	); c != 0 {
-		return nil, getLastError()
+		return nil, NewError(ErrCreateIndexFailed, int(c))
 	}
 	return &IndexFlat{&idx}, nil
 }

--- a/index_io.go
+++ b/index_io.go
@@ -16,7 +16,7 @@ func WriteIndex(idx Index, filename string) error {
 	cfname := C.CString(filename)
 	defer C.free(unsafe.Pointer(cfname))
 	if c := C.faiss_write_index_fname(idx.cPtr(), cfname); c != 0 {
-		return getLastError()
+		return NewError(ErrWriteIndexFailed, int(c))
 	}
 	return nil
 }
@@ -32,7 +32,7 @@ func WriteIndexIntoBuffer(idx Index) ([]byte, error) {
 		&tempBuf,
 	); c != 0 {
 		C.faiss_free_buf(&tempBuf)
-		return nil, getLastError()
+		return nil, NewError(ErrWriteIndexFailed, int(c))
 	}
 
 	// at this point, the idx has a valid ref count. furthermore, the index is
@@ -89,7 +89,7 @@ func ReadIndexFromBuffer(buf []byte, ioflags int) (*IndexImpl, error) {
 		size,
 		C.int(ioflags),
 		&idx.idx); c != 0 {
-		return nil, getLastError()
+		return nil, NewError(ErrReadIndexFailed, int(c))
 	}
 
 	ptr = nil
@@ -114,7 +114,7 @@ func ReadIndex(filename string, ioflags int) (*IndexImpl, error) {
 	defer C.free(unsafe.Pointer(cfname))
 	var idx faissIndex
 	if c := C.faiss_read_index_fname(cfname, C.int(ioflags), &idx.idx); c != 0 {
-		return nil, getLastError()
+		return nil, NewError(ErrReadIndexFailed, int(c))
 	}
 	return &IndexImpl{&idx}, nil
 }
@@ -130,7 +130,7 @@ func WriteBinaryIndexIntoBuffer(idx BinaryIndex) ([]byte, error) {
 		&tempBuf,
 	); c != 0 {
 		C.faiss_free_buf(&tempBuf)
-		return nil, getLastError()
+		return nil, NewError(ErrWriteIndexFailed, int(c))
 	}
 
 	val := unsafe.Slice((*byte)(unsafe.Pointer(tempBuf)), uint(bufSize))
@@ -153,7 +153,7 @@ func ReadBinaryIndexFromBuffer(buf []byte, ioflags int) (*BinaryIndexImpl, error
 		size,
 		C.int(ioflags),
 		&bIdx.bIdx); c != 0 {
-		return nil, getLastError()
+		return nil, NewError(ErrReadIndexFailed, int(c))
 	}
 
 	return &BinaryIndexImpl{&bIdx}, nil

--- a/index_io.go
+++ b/index_io.go
@@ -16,7 +16,7 @@ func WriteIndex(idx Index, filename string) error {
 	cfname := C.CString(filename)
 	defer C.free(unsafe.Pointer(cfname))
 	if c := C.faiss_write_index_fname(idx.cPtr(), cfname); c != 0 {
-		return NewError(ErrWriteIndexFailed, int(c))
+		return newFaissError(ErrWriteIndexFailed, getLastError(), int(c))
 	}
 	return nil
 }
@@ -32,7 +32,7 @@ func WriteIndexIntoBuffer(idx Index) ([]byte, error) {
 		&tempBuf,
 	); c != 0 {
 		C.faiss_free_buf(&tempBuf)
-		return nil, NewError(ErrWriteIndexFailed, int(c))
+		return nil, newFaissError(ErrWriteIndexFailed, getLastError(), int(c))
 	}
 
 	// at this point, the idx has a valid ref count. furthermore, the index is
@@ -89,7 +89,7 @@ func ReadIndexFromBuffer(buf []byte, ioflags int) (*IndexImpl, error) {
 		size,
 		C.int(ioflags),
 		&idx.idx); c != 0 {
-		return nil, NewError(ErrReadIndexFailed, int(c))
+		return nil, newFaissError(ErrReadIndexFailed, getLastError(), int(c))
 	}
 
 	ptr = nil
@@ -114,7 +114,7 @@ func ReadIndex(filename string, ioflags int) (*IndexImpl, error) {
 	defer C.free(unsafe.Pointer(cfname))
 	var idx faissIndex
 	if c := C.faiss_read_index_fname(cfname, C.int(ioflags), &idx.idx); c != 0 {
-		return nil, NewError(ErrReadIndexFailed, int(c))
+		return nil, newFaissError(ErrReadIndexFailed, getLastError(), int(c))
 	}
 	return &IndexImpl{&idx}, nil
 }
@@ -130,7 +130,7 @@ func WriteBinaryIndexIntoBuffer(idx BinaryIndex) ([]byte, error) {
 		&tempBuf,
 	); c != 0 {
 		C.faiss_free_buf(&tempBuf)
-		return nil, NewError(ErrWriteIndexFailed, int(c))
+		return nil, newFaissError(ErrWriteIndexFailed, getLastError(), int(c))
 	}
 
 	val := unsafe.Slice((*byte)(unsafe.Pointer(tempBuf)), uint(bufSize))
@@ -153,7 +153,7 @@ func ReadBinaryIndexFromBuffer(buf []byte, ioflags int) (*BinaryIndexImpl, error
 		size,
 		C.int(ioflags),
 		&bIdx.bIdx); c != 0 {
-		return nil, NewError(ErrReadIndexFailed, int(c))
+		return nil, newFaissError(ErrReadIndexFailed, getLastError(), int(c))
 	}
 
 	return &BinaryIndexImpl{&bIdx}, nil

--- a/index_ivf.go
+++ b/index_ivf.go
@@ -20,7 +20,7 @@ func (idx *faissIndex) SetDirectMap(mapType int) (err error) {
 		ivfPtr,
 		C.int(mapType),
 	); c != 0 {
-		err = NewError(ErrSetParamsFailed, int(c))
+		err = newFaissError(ErrSetParamsFailed, getLastError(), int(c))
 	}
 	return err
 }
@@ -71,7 +71,7 @@ func (idx *faissIndex) SetQuantizers(srcIndex Index) error {
 	}
 	c := C.faiss_Set_quantizers(idx.idx, srcIndex.cPtr())
 	if c != 0 {
-		return NewError(ErrSetQuantizerFailed, int(c))
+		return newFaissError(ErrSetQuantizerFailed, getLastError(), int(c))
 	}
 	return nil
 }

--- a/index_ivf.go
+++ b/index_ivf.go
@@ -29,12 +29,12 @@ func (idx *faissIndex) GetSubIndex() (Index, error) {
 
 	ptr := C.faiss_IndexIDMap2_cast(idx.cPtr())
 	if ptr == nil {
-		return nil, ErrNotIVFIndex
+		return nil, ErrNotIDMapIndex
 	}
 
 	subIdx := C.faiss_IndexIDMap2_sub_index(ptr)
 	if subIdx == nil {
-		return nil, ErrNotIVFIndex
+		return nil, ErrNotIDMapIndex
 	}
 
 	return &IndexImpl{&faissIndex{subIdx}}, nil
@@ -69,16 +69,9 @@ func (idx *faissIndex) SetQuantizers(srcIndex Index) error {
 		!(idx.IsSQIndex() && srcIndex.IsSQIndex()) {
 		return ErrSetQuantizerNotSupported
 	}
-
-	srcIndexPtr := srcIndex.cPtr()
-	if srcIndexPtr == nil {
-		return ErrIndexNil
-	}
-
-	c := C.faiss_Set_quantizers(idx.idx, srcIndexPtr)
+	c := C.faiss_Set_quantizers(idx.idx, srcIndex.cPtr())
 	if c != 0 {
-		return NewError(ErrSetParamsFailed, int(c))
+		return NewError(ErrSetQuantizerFailed, int(c))
 	}
-
 	return nil
 }

--- a/index_ivf.go
+++ b/index_ivf.go
@@ -9,21 +9,18 @@ package faiss
 #include <faiss/c_api/IndexScalarQuantizer_c.h>
 */
 import "C"
-import (
-	"fmt"
-)
 
 func (idx *faissIndex) SetDirectMap(mapType int) (err error) {
 
 	ivfPtr := C.faiss_IndexIVF_cast(idx.cPtr())
 	if ivfPtr == nil {
-		return errNotIVFIndex
+		return ErrNotIVFIndex
 	}
 	if c := C.faiss_IndexIVF_set_direct_map(
 		ivfPtr,
 		C.int(mapType),
 	); c != 0 {
-		err = getLastError()
+		err = NewError(ErrSetParamsFailed, int(c))
 	}
 	return err
 }
@@ -32,12 +29,12 @@ func (idx *faissIndex) GetSubIndex() (Index, error) {
 
 	ptr := C.faiss_IndexIDMap2_cast(idx.cPtr())
 	if ptr == nil {
-		return nil, fmt.Errorf("index is not a id map")
+		return nil, ErrNotIVFIndex
 	}
 
 	subIdx := C.faiss_IndexIDMap2_sub_index(ptr)
 	if subIdx == nil {
-		return nil, fmt.Errorf("couldn't retrieve the sub index")
+		return nil, ErrNotIVFIndex
 	}
 
 	return &IndexImpl{&faissIndex{subIdx}}, nil
@@ -70,17 +67,17 @@ func (idx *faissIndex) IsSQIndex() bool {
 func (idx *faissIndex) SetQuantizers(srcIndex Index) error {
 	if !(idx.IsIVFIndex() && srcIndex.IsIVFIndex()) &&
 		!(idx.IsSQIndex() && srcIndex.IsSQIndex()) {
-		return fmt.Errorf("faissIndex SetQuantizers: %w, index type not supported", errFailedToSetQuantizers)
+		return ErrSetParamsFailed
 	}
 
 	srcIndexPtr := srcIndex.cPtr()
 	if srcIndexPtr == nil {
-		return fmt.Errorf("coarse quantizer is not valid")
+		return ErrSourceIndexNil
 	}
 
-	err := C.faiss_Set_quantizers(idx.idx, srcIndexPtr)
-	if err != 0 {
-		return fmt.Errorf("faissIndex SetQuantizers: %w", errFailedToSetQuantizers)
+	c := C.faiss_Set_quantizers(idx.idx, srcIndexPtr)
+	if c != 0 {
+		return NewError(ErrSetParamsFailed, int(c))
 	}
 
 	return nil

--- a/index_ivf.go
+++ b/index_ivf.go
@@ -67,12 +67,12 @@ func (idx *faissIndex) IsSQIndex() bool {
 func (idx *faissIndex) SetQuantizers(srcIndex Index) error {
 	if !(idx.IsIVFIndex() && srcIndex.IsIVFIndex()) &&
 		!(idx.IsSQIndex() && srcIndex.IsSQIndex()) {
-		return ErrSetParamsFailed
+		return ErrSetQuantizerNotSupported
 	}
 
 	srcIndexPtr := srcIndex.cPtr()
 	if srcIndexPtr == nil {
-		return ErrSourceIndexNil
+		return ErrIndexNil
 	}
 
 	c := C.faiss_Set_quantizers(idx.idx, srcIndexPtr)

--- a/search_params.go
+++ b/search_params.go
@@ -75,7 +75,7 @@ func NewSearchParams(idx Index, params json.RawMessage, selector Selector,
 		rv := &SearchParams{}
 		// Create standard SearchParameters for non-IVF index
 		if c := C.faiss_SearchParameters_new(&rv.sp, sel); c != 0 {
-			return nil, fmt.Errorf("failed to create faiss search params")
+			return nil, ErrCreateParamsFailed
 		}
 		return rv, nil
 	}
@@ -133,7 +133,7 @@ func buildIVFSearchParams(maxCodes, nprobe int, sel *C.FaissIDSelector) (*Search
 		C.size_t(nprobe),
 		C.size_t(maxCodes),
 	); c != 0 {
-		return nil, fmt.Errorf("failed to create faiss IVF search params")
+		return nil, ErrCreateParamsFailed
 	}
 
 	return sp, nil
@@ -147,7 +147,7 @@ func buildRaBitQSearchParams(maxCodes, nprobe int, sel *C.FaissIDSelector) (*Sea
 		C.size_t(nprobe),
 		C.size_t(maxCodes),
 	); c != 0 {
-		return nil, fmt.Errorf("failed to create faiss IVF RaBitQ search params")
+		return nil, ErrCreateParamsFailed
 	}
 
 	return sp, nil
@@ -163,7 +163,7 @@ func NewStandardSearchParams(selector Selector) (*SearchParams, error) {
 	}
 	rv := &SearchParams{}
 	if c := C.faiss_SearchParameters_new(&rv.sp, sel); c != 0 {
-		return nil, fmt.Errorf("failed to create faiss search params")
+		return nil, ErrCreateParamsFailed
 	}
 	return rv, nil
 }
@@ -185,7 +185,7 @@ func NewBinarySearchParams(idx BinaryIndex, params json.RawMessage, selector Sel
 		rv := &SearchParams{}
 		// Create standard SearchParameters for non-IVF index
 		if c := C.faiss_SearchParameters_new(&rv.sp, sel); c != 0 {
-			return nil, fmt.Errorf("failed to create faiss search params")
+			return nil, ErrCreateParamsFailed
 		}
 		return rv, nil
 	}

--- a/selector.go
+++ b/selector.go
@@ -46,7 +46,7 @@ func NewIDSelectorRange(imin, imax int64) (Selector, error) {
 	var sel *C.FaissIDSelectorRange
 	c := C.faiss_IDSelectorRange_new(&sel, C.idx_t(imin), C.idx_t(imax))
 	if c != 0 {
-		return nil, NewError(ErrCreateSelectorFailed, int(c))
+		return nil, newFaissError(ErrCreateSelectorFailed, getLastError(), int(c))
 	}
 	return &IDSelector{sel: (*C.FaissIDSelector)(sel)}, nil
 }
@@ -59,7 +59,7 @@ func NewIDSelectorBatch(indices []int64) (Selector, error) {
 		C.size_t(len(indices)),
 		(*C.idx_t)(&indices[0]),
 	); c != 0 {
-		return nil, NewError(ErrCreateSelectorFailed, int(c))
+		return nil, newFaissError(ErrCreateSelectorFailed, getLastError(), int(c))
 	}
 	return &IDSelector{sel: (*C.FaissIDSelector)(sel)}, nil
 }
@@ -78,7 +78,7 @@ func NewIDSelectorBatchNot(exclude []int64) (Selector, error) {
 		batchSelector.Get(),
 	); c != 0 {
 		batchSelector.Delete()
-		return nil, NewError(ErrCreateSelectorFailed, int(c))
+		return nil, newFaissError(ErrCreateSelectorFailed, getLastError(), int(c))
 	}
 	return &IDSelector{exclude: true,
 		sel:   (*C.FaissIDSelector)(sel),
@@ -98,7 +98,7 @@ func NewIDSelectorBitmap(bitmap []byte) (Selector, error) {
 		C.size_t(len(bitmap)),
 		(*C.uint8_t)(&bitmap[0]),
 	); c != 0 {
-		return nil, NewError(ErrCreateSelectorFailed, int(c))
+		return nil, newFaissError(ErrCreateSelectorFailed, getLastError(), int(c))
 	}
 	return &IDSelector{sel: (*C.FaissIDSelector)(sel)}, nil
 }
@@ -120,7 +120,7 @@ func NewIDSelectorBitmapNot(bitmap []byte) (Selector, error) {
 		bitmapSelector.Get(),
 	); c != 0 {
 		bitmapSelector.Delete()
-		return nil, NewError(ErrCreateSelectorFailed, int(c))
+		return nil, newFaissError(ErrCreateSelectorFailed, getLastError(), int(c))
 	}
 	return &IDSelector{exclude: true,
 		sel:   (*C.FaissIDSelector)(sel),

--- a/selector.go
+++ b/selector.go
@@ -46,7 +46,7 @@ func NewIDSelectorRange(imin, imax int64) (Selector, error) {
 	var sel *C.FaissIDSelectorRange
 	c := C.faiss_IDSelectorRange_new(&sel, C.idx_t(imin), C.idx_t(imax))
 	if c != 0 {
-		return nil, getLastError()
+		return nil, NewError(ErrCreateSelectorFailed, int(c))
 	}
 	return &IDSelector{sel: (*C.FaissIDSelector)(sel)}, nil
 }
@@ -59,7 +59,7 @@ func NewIDSelectorBatch(indices []int64) (Selector, error) {
 		C.size_t(len(indices)),
 		(*C.idx_t)(&indices[0]),
 	); c != 0 {
-		return nil, getLastError()
+		return nil, NewError(ErrCreateSelectorFailed, int(c))
 	}
 	return &IDSelector{sel: (*C.FaissIDSelector)(sel)}, nil
 }
@@ -78,7 +78,7 @@ func NewIDSelectorBatchNot(exclude []int64) (Selector, error) {
 		batchSelector.Get(),
 	); c != 0 {
 		batchSelector.Delete()
-		return nil, getLastError()
+		return nil, NewError(ErrCreateSelectorFailed, int(c))
 	}
 	return &IDSelector{exclude: true,
 		sel:   (*C.FaissIDSelector)(sel),
@@ -98,7 +98,7 @@ func NewIDSelectorBitmap(bitmap []byte) (Selector, error) {
 		C.size_t(len(bitmap)),
 		(*C.uint8_t)(&bitmap[0]),
 	); c != 0 {
-		return nil, getLastError()
+		return nil, NewError(ErrCreateSelectorFailed, int(c))
 	}
 	return &IDSelector{sel: (*C.FaissIDSelector)(sel)}, nil
 }
@@ -120,7 +120,7 @@ func NewIDSelectorBitmapNot(bitmap []byte) (Selector, error) {
 		bitmapSelector.Get(),
 	); c != 0 {
 		bitmapSelector.Delete()
-		return nil, getLastError()
+		return nil, NewError(ErrCreateSelectorFailed, int(c))
 	}
 	return &IDSelector{exclude: true,
 		sel:   (*C.FaissIDSelector)(sel),


### PR DESCRIPTION
- **Currently**: every failing FAISS C call funnels through
     `getLastError()`, which reads `C.faiss_get_last_error()` and wraps that
     string in `errors.New(...)` before returning it to the caller.
- **Why this is an issue**: `faiss_get_last_error()` is backed by a single
     process-global string on the FAISS side, so under concurrent use another
     goroutine can overwrite it between the failing C call and our read - we end
     up returning the wrong message; the FAISS C return code is
     discarded; and because every error is an ad-hoc `errors.New(string)`,
     callers have no stable value to match against with `errors.Is`.
- **This PR introduces**: a dedicated `errors.go` with fixed sentinel errors
      (`ErrAddFailed`, `ErrSearchFailed`, `ErrInspectIndexFailed`,
     `ErrGPUOperationFailed`, ...) usable via `errors.Is`, plus a `faissError`
     type that preserves the original error message and code while adding an 
     error type which can be used to categorize the errors returned by the package. 
- **Unifies**: the scattered ad-hoc errors (`errNotIVFIndex`,
     `errNoGPUDevices`, `errFailedToSetQuantizers`, ...) into one themed set.