### PR TITLE
Add `RealToBinary` golang binding

### DIFF
--- a/faiss.go
+++ b/faiss.go
@@ -9,6 +9,7 @@ package faiss
 
 #include <faiss/c_api/Index_c.h>
 #include <faiss/c_api/utils/distances_c.h>
+#include <faiss/c_api/utils/utils_c.h>
 */
 import "C"
 
@@ -32,4 +33,20 @@ func NormalizeVector(vector []float32) []float32 {
 		(*C.float)(&vector[0]))
 
 	return vector
+}
+
+// RealToBinary converts n real-valued vectors into binary vectors.
+// Each output bit is 1 if the corresponding input value is > 0,
+// and 0 otherwise. d must be a multiple of 8.
+// The returned slice has length n * (d / 8).
+func RealToBinary(x []float32, d int) []uint8 {
+	n := len(x) / d
+	out := make([]uint8, n*(d/8))
+	C.faiss_real_to_binary(
+		C.size_t(n),
+		C.size_t(d),
+		(*C.float)(&x[0]),
+		(*C.uint8_t)(&out[0]),
+	)
+	return out
 }


### PR DESCRIPTION
- Add a go binding for the `faiss_real_to_binary` API that binarizes a batch of `n * d` input vector table in LSB format.
- Requires: https://github.com/blevesearch/faiss/pull/85