### PR TITLE
MB-72262: Probe GPU devices for health

### DIFF
--- a/gpu.go
+++ b/gpu.go
@@ -215,10 +215,10 @@ func newGPUSnapshotStore() *gpuSnapshotStore {
 	snapshots := make([]*gpuSnapshot, gpuCount)
 	for device := 0; device < gpuCount; device++ {
 		cDev := C.int(device)
+		totMemory := uint64(0)
 		// first probe if the device is healthy and can be used
-		if c := C.faiss_probe_gpu(cDev); c == 0 {
-			// get total free memory for the device
-			totMemory := uint64(0)
+		var probeResult C.int
+		if c := C.faiss_probe_gpu(cDev, &probeResult); c == 0 && probeResult == 0 {
 			var freeBytes C.size_t
 			if c := C.faiss_gpu_free_memory(
 				cDev,

--- a/gpu.go
+++ b/gpu.go
@@ -214,14 +214,18 @@ type gpuSnapshotStore struct {
 func newGPUSnapshotStore() *gpuSnapshotStore {
 	snapshots := make([]*gpuSnapshot, gpuCount)
 	for device := 0; device < gpuCount; device++ {
-		// get total free memory for the GPU device.
-		totMemory := uint64(0)
-		var freeBytes C.size_t
-		if c := C.faiss_gpu_free_memory(
-			C.int(device),
-			&freeBytes,
-		); c == 0 {
-			totMemory = uint64(freeBytes)
+		cDev := C.int(device)
+		// first probe if the device is healthy and can be used
+		if c := C.faiss_probe_gpu(cDev); c == 0 {
+			// get total free memory for the device
+			totMemory := uint64(0)
+			var freeBytes C.size_t
+			if c := C.faiss_gpu_free_memory(
+				cDev,
+				&freeBytes,
+			); c == 0 {
+				totMemory = uint64(freeBytes)
+			}
 		}
 		// if we fail to get the free memory for the GPU,
 		// we still create a snapshot with 0 total and free memory,


### PR DESCRIPTION
- Currently, we use the getNumDevices API to catch any CUDA initialization issues and disable GPU usage if we fail to get the number of usable GPUs. Example of caught errors are:
     - `CUDA error 100: cudaErrorNoDevice` 
     - `CUDA error  35: cudaErrorInsufficientDriver` 
     - `CUDA error 999: cudaErrorUnknown`
- However, in a test we observed a crash stemming from `CUDA error 46 CUDA-capable device(s) is/are busy or unavailable`, this is caused by trying to poll the GPUs to get the memory information, which in turn initializes CUDA driver context and promptly crashes the process.
- To ensure that we do not crash the process, use the GPU probe API, which will initalize the  CUDA driver context gracefully.
- Requires: https://github.com/blevesearch/faiss/pull/86